### PR TITLE
DOC editing pass fixing typos and improving organization

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -4,7 +4,7 @@ Putting the documentation within the source project gives us a straightforward w
 the project documentation and source code in sync.
 This also makes it easier for developers to collaborate by
 using a single source for document files, using git as a document repository, and
-using github's moderation and approval process.  Documentation changes go through
+using GitHub's moderation and approval process.  Documentation changes go through
 the same approval processes as the code.
 
 While there may be documents in progress within this /doc folder, only files actually
@@ -29,7 +29,12 @@ quick_start_
 
 sphinx_build
     Sphinx configuration and build files for the Ostro Project's website.  When processed, 
-    html output is contained within this folder in the _build/html folder.
+    HTML output is contained within this folder in the _build/html folder. We use
+    two different themes: one simple theme for generating an HTML site that can be
+    viewed locally (this is the theme included with the source code), and a second
+    more complex theme that's used to generate the public facing website accessed
+    via the internet.  This latter theme is matched to the theme used on the main
+    ostroproject.org website and maintained by the website team.
 
 
 .. _howtos: howtos

--- a/doc/architecture/efi-boot.rst
+++ b/doc/architecture/efi-boot.rst
@@ -13,19 +13,19 @@ Background
 On typical distros (Fedora, Ubuntu, etc.) there are distinct
 components that implement:
 
-- boot loader
-- kernel command line (usually part of the bootloader configuration)
-- kernel
+- boot loader,
+- kernel command line (usually part of the bootloader configuration),
+- kernel, and
 - initramfs (if present)
 
 This typical model provides more choices to the user, but it introduces
-additional points of failure in the security chain, because the EFI BIOS
+additional points of failure in the security chain because the EFI BIOS
 only verifies the authenticity of the bootloader.
-The bootloader has the burden of verifying the kernel, the initramfs
+The bootloader has the burden of verifying the kernel, the initramfs,
 and its own configuration data, which must be signed individually.
 
 The first part (BIOS verification of the bootloader) cannot be avoided,
-because it's the first ring ofthe chain of trust.
+because it's the first ring of the chain of trust.
 The following (BIOS verification of kernel and initramfs) can only
 introduce an additional risk, due to different implementation of what
 is basically the same set of functionality already present in the BIOS.
@@ -35,37 +35,37 @@ EFI support in Ostro OS
 =======================
 Ostro OS relies on a single-binary approach, where the bootloader
 (but only a small part of it), the kernel command line, the kernel and
-the initramfs are all pacakged in a single file, which then gets signed.
+the initramfs are all packaged in a single signed file.
 
-Each component is placed in a separate section, inside the combo-binary.
-
+Each component is placed in a separate section within the combo-binary.
 Only the EFI stub is used from the bootloader.
+
 The stub accomplishes these main functions:
 
-- make the entire combo binary look like an EFI application, to the EFI BIOS
-- extract the kernel command line from its section inside the binary
-- handover the execution to the kernel section.
+- Make the entire combo binary look like an EFI application to the EFI BIOS.
+- Extract the kernel command line from its section inside the binary.
+- Hand-over execution to the kernel section.
 
 Advantages
 ----------
 
-- only one file to handle, where most of the handling is performed by the
-  BIOS, so that only one implementation exists for each functionality.
-- no risk of components going out of sync: there is only one file to update
-- less vulnerability to corruption of the EFI partition, during update.
-  The EFI partition is of type FAT, as required by the EFI specifications,
-  which means that it is significantly more exposed to corruptions than other
-  more modern and saner file systems.
+- Only one file is handled, where most of the handling is performed by the
+  BIOS, and only one implementation exists for each functionality.
+- There is no risk of components going out of sync: there is only one file to update.
+- There is less vulnerability to corruption of the EFI partition, during update.
+  The EFI partition is of type FAT, as required by the EFI specifications.
+  It is significantly more exposed to corruptions than other
+  more modern file systems.
 
 Disadvantages
 -------------
 
-- in case one wants to have multiple boot options, this needs to be supported
-  through the EFI BIOS (more on this in the following point) and not all the
-  BIOS implementations shine for supporting very well parts of the EFI
-  specifications that are not indispensible for booting.
-- the implementation of multi-boot selection will require either the creation
+- Multiple boot options support requires support
+  through the EFI BIOS (more on this in the following point) but not all
+  BIOS implementations fully implement parts of the EFI
+  specifications that are not indispensable for booting.
+- The implementation of multi-boot selection will require either the creation
   of an additional EFI binary or the implementation of an EFI shell script.
   This sort of expertise might not be very common among Ostro developers.
-- changing the content of the command line requires rebuilding the EFI combo,
+- Changing the contents of the command line requires rebuilding the EFI combo,
   unless there is a mechanism in place to support an alternative (to be developed).

--- a/doc/architecture/security-threat-analysis.rst
+++ b/doc/architecture/security-threat-analysis.rst
@@ -107,27 +107,27 @@ Adversaries
                                                                           privilege  potential
                                                                           level      effort level
 ======= ================== ======================= ====================== ========== ==============
-1.      Ostro OS           Damage vendor's         Network adversary      Low        High
+\       Ostro OS           Damage vendor's         Network adversary      Low        High
         download and       brand;
         update             personal
         infrastructure     reputation;
         attacker           access to user
                            data and device
-2.      Authorized device  Override behavior       Local physical access  Medium     Medium
+\       Authorized device  Override behavior       Local physical access  Medium     Medium
         user               defined by the
                            service provider
-3.      Malicious          Steal the physical      Local physical access  Low        Varies
-        unauthorized       device and/or data in
+\       Malicious          Steal the physical      Local physical access  Low        Varies
+        unauthorized       device or data in
         device user        it
-4.      Network attacker   Access to user data     Network adversary      Low        Varies
+\       Network attacker   Access to user data     Network adversary      Low        Varies
         (MITM attacker,    and device;
         script kiddie,     reputation
         botnet owner,
         etc.)
-5.      Authorized         Insider who wants to    Authorized adversary   High       Low
+\       Authorized         Insider who wants to    Authorized adversary   High       Low
         malicious project  harm
         team admin
-6.      Malware developer  Access to user data     Local, non-physical    Medium     High (code
+\       Malware developer  Access to user data     Local, non-physical    Medium     High (code
                            and device; reputation  access (application               injection),
                                                    intentionally gets                Medium (app
                                                    installed or code                 developer)
@@ -152,7 +152,7 @@ Application data           Log files, stored      Medium        Individual appli
                            sensor data, media
                            files, application
                            credentials/keys
-System data and files      Credentials/keys,      Medium        System components (read/write),      Device
+System data and files      credentials/keys,      Medium        System components (read/write),      Device
                            service configuration,               applications (read-only)
                            executables and
                            libraries
@@ -168,8 +168,8 @@ Device resources           CPU, memory, disk      Medium        Applications and
 ========================== ====================== ============= ==================================== =============
 
 The "Attack Points" column distinguishes between assets accessed
-through the device and thus where Ostro OS itselfs must protect the
-assets and other assets where mitigation must happen elsewhere.
+through the device (and where Ostro OS itself must protect the
+assets), and other assets (where mitigation must happen elsewhere).
 
 
 Attack surfaces
@@ -204,7 +204,7 @@ Lib-2 Malware developer/ Application data      Exploiting a local or remote vuln
 Lib-3 Network attacker   Application data,     Pre-condition: attacker is able to upload a binary or runnable code
                          sensor data, system   to the system. Method: attacker executes a malicious binary or
                          data                  runnable code in the system
-Lib-4 Network attacker   System data           An attacker can access the device when it’s being provisioned
+Lib-4 Network attacker   System data           An attacker can access the device when it's being provisioned
                                                (taken into use) because of insecure network provisioning or
                                                insecure default configuration
 Lib-5 Download and       Releases and tools    Attacker has managed to compromise an Ostro OS update server
@@ -387,7 +387,7 @@ Lib-5
  Notification mechanism. If swupd is used wrapped in Soletta, it will
  report back to the caller about the error. The caller must then
  notify the user or do other appropriate actions based on
- preconfigured policies, such as changing the update mirror.
+ pre-configured policies, such as changing the update mirror.
 
 Lib-6
 -----
@@ -553,7 +553,7 @@ App-3
  Soletta features for secure provisioning of sensors. For more complex
  authentication needs, applications need to carry the burden by having
  authorization mechanism such as a certificate for accessing
- preconfigured sensors.
+ pre-configured sensors.
 
 *Extensions*:
 

--- a/doc/architecture/software-update.rst
+++ b/doc/architecture/software-update.rst
@@ -8,19 +8,22 @@ Introduction
 
 Ostro-based software can be deployed to a target device in two ways:
 
-- full disk flashing
+- Full Disk Flashing
+
   A new software image is built and installed, completely replacing
   what was previously present on the device.
   It can be useful for initializing a device with Ostro.
-- software update
-  This is a component that Ostro borrows from The Clear Linux* OS
-  for Intel® Architecture and consists of 2 entities: server and client.
 
-Description
-===========
+- Software Update
+
+  This is a component that Ostro borrows from The Clear Linux\* OS
+  for Intel |reg| Architecture and consists of both a server and client
+  component.
+
 
 Software Update Server
-----------------------
+======================
+
 The software update server runs elsewhere than on the device, for example
 on a CI (Continuous Integration) server.
 For each build, the server generates information specific to that build
@@ -38,7 +41,8 @@ update client will treat them as trusted.
 
 
 Software Update Client
-----------------------
+======================
+
 The client runs on the device and is responsible of downloading, verifying
 (signature verification to be implemented) and applying the updates.
 It can also restore to their pristine state files that were present in the
@@ -46,7 +50,8 @@ initial sw image and have been modified.
 
 
 SW Bundles
-----------
+==========
+
 The software update mechanism supports the concept of bundles_: groups of files
 that provide one functionality.
 It is similar to the concept of package used in the vast majority of linux distros,

--- a/doc/architecture/system-and-security-architecture.rst
+++ b/doc/architecture/system-and-security-architecture.rst
@@ -18,7 +18,7 @@ Providers, and developers building their own devices.
 
 This document introduces key concepts in the Ostro OS and how they fit
 together. The target audience is developers who want to learn about
-Ostro OS and/or use the OS in their own product. Application
+Ostro OS or use the OS in their own product. Application
 developers will also find this to be useful background information.
 There will also be documentation more focused on application
 development and installation.  The :ref:`Building Images` tech note
@@ -54,7 +54,7 @@ places where the security model differs from baseline Linux security
 that can be expected from any mainstream desktop Linux distribution.
 
 For a discussion of potential other security mechanisms see the
-:ref:`security-threat-analysis` documenentation.
+:ref:`security-threat-analysis` documentation.
 
 
 Key Security Concepts
@@ -62,11 +62,11 @@ Key Security Concepts
 
 * Scalable Security: Protection mechanisms can be turned on to
   increase security (defense in depth) or turned off to decrease
-  overhead and/or complexity. However, not all combinations are
+  overhead and complexity. However, not all combinations are
   tested, see `Production and Development Images`_ later in this document.
 
 * Unix DAC is used to separate applications. Each application runs
-  under a different uid. Supporting multiple real users of the same
+  under a different UID. Supporting multiple real users of the same
   device is left to applications to support.
 
 * Permission checks are based on Unix group membership.
@@ -74,7 +74,7 @@ Key Security Concepts
 * When using DAC alone, applications can communicate with each
   other. Application authors must be careful about setting permission
   bits as intended to prevent that. Because applications are trusted,
-  this is acceptable. When that is undesirable and/or to mitigate
+  this is acceptable. When that is undesirable or to mitigate
   risks when applications get compromised, optionally Smack as a MAC
   mechanism can be used to separate applications further (*TODO*).
 
@@ -201,28 +201,29 @@ the same writable partition.
   Persistent data which can be written on the device. Protected by
   IMA/EVM with hashes created on-the-fly by the kernel on the device.
 
-``/tmp`` ``/var/run``
+``/tmp`` and ``/var/run``
   A tmpfs which will not survive a reboot.
 
 ``/home``
   Persistent, read/write, no IMA/EVM. Each application gets its own
   home directory with access limited to the application.
 
-``/etc`` and the files in it are part of the core OS and thus considered
-read-only. However, there are a few noteworthy exceptions:
+``/etc``
+  The files in it are part of the core OS and thus considered
+  read-only. However, there are a few noteworthy exceptions:
 
 ``/etc/ld.so.cache``
- Its content depends on the currently installed shared libraries,
- which may vary by device. Therefore it needs to be updated on the
- device after system software installation or updates. Its real
- location thus is in /var (*TODO*).
+  Its content depends on the currently installed shared libraries,
+  which may vary by device. Therefore it needs to be updated on the
+  device after system software installation or updates. Its real
+  location thus is in /var (*TODO*).
 
 ``/etc/machine-id``
- Currently systemd creates a machine ID when booting and writes it to
- ``/etc/machine-id`` when ``/etc`` becomes writeable. When moving to the strict
- IMA policy, we need to prevent that (because the file would become
- unreadable, which breaks several systemd services) or move it to ``/var``
- (*TODO*).
+  Currently systemd creates a machine ID when booting and writes it to
+  ``/etc/machine-id`` when ``/etc`` becomes writeable. When moving to the strict
+  IMA policy, we need to prevent that (because the file would become
+  unreadable, which breaks several systemd services) or move it to ``/var``
+  (*TODO*).
 
 
 User, Group and Privilege Management
@@ -281,7 +282,7 @@ Applications
 ============
 
 At the moment, applications are only supported when built
-into the image (“pre-installed applications”) that is installed on a
+into the image (“pre-installed applications”) installed on a
 device. Such applications can use the normal Yocto Project configuration
 tools for creating
 the user they run under, install files in the normal root file system,
@@ -371,7 +372,7 @@ Core OS Hardening
 
 *TODO*: instructions how to deal with services needing to talk with each other, D-Bus policies etc.
 
-*TODO*: Recommended Systemd options for services.
+*TODO*: Recommended systemd options for services.
 
 *TODO*: Security processes followed by Ostro OS? Information about found vulnerabilities etc.
 

--- a/doc/howtos/booting-and-installation.rst
+++ b/doc/howtos/booting-and-installation.rst
@@ -24,8 +24,8 @@ Ostro OS Images
 As explained in the :ref:`Building Images` tech note, there are several image variants available
 depending on your need.  For simplicity and the needs of this tech note, we'll use the dev image that includes
 additional build and debugging tools that wouldn't typically be included in a production device image.  This
-dev image also permits root login access at the console and via SSH, something that normally would not be available
-in a production device image either.
+dev image also will auto-login as root at the console and provides root access via SSH, something that normally would not be available
+in a production device image but is quite useful during development.
 
 Using dd to Create Bootable Media
 =================================
@@ -59,14 +59,17 @@ USB thumb drive or SD card.  The typical way to do this is with the :command:`dd
 MinnowBoard MAX
 ================
 
-The `MinnowBoard MAX`_ is a small formfactor board with an Intel |reg| Atom |trade| E3825 dual-core processor (supporting both 32-bit and 64-bit images).  
+The `MinnowBoard MAX`_ is a small form-factor board with an Intel |reg| Atom |trade| E3825 dual-core processor.  
 Once you have the Ostro OS image on a USB thumb drive (or SD card), you can use this to boot your MinnowBoard MAX-compatible board as you would
 most any Intel UEFI-based system.  The procedure will be similar for other boards so we’ll use this as an example.  
 See http://wiki.minnowboard.org for additional information about setting up the MinnowBoard hardware. 
 
-It's important to use a current version of firmware on your board, so we recommend checking this 
-first and updating the firmware if needed using the instructions 
-at http://wiki.minnowboard.org/MinnowBoard_MAX_HW_Setup 
+.. note::
+
+    It's important to use a current version of firmware on your board, so we recommend checking this 
+    first and updating the firmware if needed using the instructions 
+    at http://wiki.minnowboard.org/MinnowBoard_MAX_HW_Setup.  Ostro OS releases are built and tested
+    with 64-bit support, so you should make sure that the firmware is also setup for 64-bit support.  
 
 Here are the basic steps for booting the Ostro OS:
 
@@ -119,4 +122,34 @@ Flashing an Intel Edison requires use of a breakout board and two micro-USB cabl
 
     #. Plug in the second micro-USB cable to the J16 connector as instructed by the running flashall script
     #. Wait for all the images to flash. You will see the progress on both the flasher and on the serial console.
-    #. Once flashing is done, the image will automatically boot up. Login as ``root``, no password is required.
+    #. Once flashing is done, the image will automatically boot up and auto-login as ``root``, no password is required.
+       
+
+Running Ostro OS in a VirtualBox\* VM
+======================================
+
+You can run an Ostro OS image within a VirtualBox virtual machine by using the pre-built ``.vdi`` file found 
+in the binary release directory (on https://download.ostroproject.org), or as the result of doing your 
+own build from source.  As with the other examples above, we recommend you start with the "dev" image.
+ 
+#. If you haven’t already done so, download and install VirtualBox (version 5.0.2 or later) 
+   on your development system from https://www.virtualbox.org/wiki/Downloads. VirtualBox uses 
+   VDI as its native disk image format so you’ll be using that file instead of the .dsk file used 
+   with real hardware platforms. 
+#. Open the VirtualBox program and start by creating a new machine, give it a name 
+   (such as "Ostro OS build#"), select "Linux" for the VM type, and 
+   "Fedora (64-bit)" for the version.  Click next.
+#. Use a minimum of 256MB RAM for the memory configuration. You can increase this if your application needs more. Click next.
+#. Select "Use an existing virtual hard disk file", click on the folder icon and select the ``.vdi`` file you downloaded 
+   or created, and select "Create" to create the hard drive.
+#. Click on the System options and remove all the boot order options other than the "Hard Disk", and check "Enable EFI (special OSes only)".
+   While still on the system configuration, click on the "Acceleration" tab and verify that 
+   "Enable VT-x/AMX-V" (HW virtualization support) is checked. Click OK.
+#. Finally, click on the "Start" arrow button and your new virtual machine will start 
+   booting the Ostro OS Dev image and auto-login as root, no password is required.
+
+If booting fails with a kernel panic, verify you’re using VirtualBox version 5.0.2 or later.  You can shut the machine down 
+by either using the :command:`shutdown now` within the running Ostro OS image, or by using the VirtualBox menu 
+Machine/ACPI-shutdown.
+
+

--- a/doc/howtos/communication-guidelines.rst
+++ b/doc/howtos/communication-guidelines.rst
@@ -4,14 +4,16 @@ Communicating Within the Ostro |trade| Project Community
 ##########################################################
 
 As the Ostro Project community grows, it's important to share design
-and implemention ideas with the whole community.  Whenever possible, 
+and implementation ideas with the whole community.  Whenever possible, 
 sharing information should be the default and not the
 exception. That means having discussions in public forums and ensuring team
 and community members not present get the same information. Exceptions
 are legal and human issues, which may have to be discussed more privately.
 
-This technical note offers some communicaiton guidelines we, as a community, 
-should work by.
+This technical note offers some communication guidelines we, as a community, 
+should work by.  You'll find a summary of resources and community
+support systems in :ref:`access-support`.
+ 
 
 Email and Mailing Lists
 =======================
@@ -20,8 +22,7 @@ Mailing lists are a convenient way to communicate with Ostro project members as
 well as other developers interested in the Ostro OS.  These lists are perhaps
 the most convenient way to track developer discussions and to ask your own
 support questions to the Ostro OS community.  You can find a list of
-the available mailing lists, how to subscribe, and what each list is used for
-from https://lists.ostroproject.org
+the available mailing lists and how to subscribe on  https://lists.ostroproject.org
 
 You can also read through
 the mailing list archives to follow past posts and discussions.
@@ -44,7 +45,8 @@ part of the Ostro OS, create or modify a reStructuredText :file:`.rst`
 file in one of the sub-folders in the meta-ostro repository :file:`doc`
 folder and submit the change for review
 in a pull request.  We're using the Sphinx document generation tools
-for processing and creating our technical documentation web content.
+for processing and creating our technical documentation web content
+found at http://ostroproject.org/documentation.
 You can find some helpful writing and formatting
 tips in the :ref:`doc_guidelines` tech note.
 
@@ -64,6 +66,10 @@ Chat
 ====
 
 You can chat online with the Ostro OS developer community and other users in
-our IRC channel...
-
-*TODO*: document chat/IRC channel
+our IRC channel ``#ostroproject`` on the freenode.net IRC server.  You can use
+the http://webchat.freenode.net web client 
+or use a client-side application
+such as :command:`pidgin`.  Communication on IRC is immediate but transient,
+making it good for meetings or a quick discussion.  (IRC discussions are
+not recorded so it's better to use the mailing list for open discussions
+with the community of developers.)

--- a/doc/howtos/howtos.rst
+++ b/doc/howtos/howtos.rst
@@ -1,6 +1,6 @@
 .. _howtos:
 
-Ostro |trade| OS Technical Notes
+Ostro |trade| OS Project Notes
 ################################
 
 Our technical documentation for the Ostro OS is being developed right along with the OS features.  
@@ -8,13 +8,23 @@ Here are some how-to technical notes that help explain how you can use Ostro OS 
 general information about the Ostro Project.
 
 
+Technical Notes
+===============
+
 .. toctree::
    :maxdepth: 1
    
-   booting-and-installation
    building-images
+   booting-and-installation
+   uefi-secure-boot
    certificate-handling
+   software-update-server
+
+Process Notes
+=============
+
+.. toctree::
+   :maxdepth: 1
+
    communication-guidelines
    doc-guidelines
-   software-update-server
-   uefi-secure-boot

--- a/doc/howtos/uefi-secure-boot.rst
+++ b/doc/howtos/uefi-secure-boot.rst
@@ -54,7 +54,7 @@ Creating and Signing a Signing Certificate
 
 Generate a signing key and sign it with the CA::
 
-    efikeygen -d ~/efi-sign/ca --signer="UEFI Test CA" --nickname="UEFI Secure Boot Signer" 
+    efikeygen -d ~/efi-sign/ca --signer="UEFI Test CA" --nickname="UEFI Secure Boot Signer" \
        --common-name="CN=UEFI Secure Boot Signer,OU=OTC,O=Intel Corporation,C=FI" \
        --url="http://www.intel.com" --serial=01
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,7 +6,7 @@
 The Ostro |trade| OS is a scalable open source operating system tailored specifically for
 IoT smart devices. 
 
-This technnical documentation will help you learn more about
+This technical documentation will help you learn more about
 the Ostro OS and how to use it to create and deploy IoT applications.
 
 
@@ -19,6 +19,7 @@ Getting Started
    quick_start/about
    quick_start/platforms
    quick_start/quick_start
+   quick_start/access-support
 
 Architecture Guides
 ###################
@@ -29,7 +30,7 @@ Architecture Guides
    architecture/architecture
 
 
-How-To Technical Notes
+How-To Project Notes
 #######################
 
 .. toctree::

--- a/doc/quick_start/access-support.rst
+++ b/doc/quick_start/access-support.rst
@@ -1,0 +1,68 @@
+.. _access-support:
+
+Ostro |trade| Project Access and Community Support Resources
+############################################################
+
+Here’s a quick summary of resources to find Ostro OS images, source code,
+documentation, and support systems:
+
+* Ostro Project Website
+   The website https://ostroproject.org is the central source of  
+   information about the Ostro Project.  On this site you'll find current information
+   about the project as well as all the relevent links to project material 
+   (including this documentation).
+
+* Image Releases
+   Pre-built Ostro OS images for all the :ref:`platforms` are available at
+   https://download.ostroproject.org
+
+   In there you’ll find folders for each of
+   the supported hardware platforms. In the platform folder, you’ll find an
+   :file:`.dsk` file that can be written directly onto a hard disk or
+   USB thumb drive and booted.  There’s also a :file:`.vdi` file for use with VirtualBox.
+
+* Software Updates
+   The Ostro OS uses a rolling updates development and release process using "bundle"  
+   technology developed by the Clear Linux\* OS for Intel |reg| Architecture team.  You 
+   can read more about bundles at `Clear Linux Project Software Update`_ and about Ostro OS
+   specifics from :ref:`software-update`
+
+.. _`Clear Linux Project Software Update`: https://clearlinux.org/features/software-update
+   
+* Source Code on GitHub
+   Ostro OS source code is maintained on a public GitHub repository at
+   https://github.com/ostroproject. Check out the README there for more information
+   about the repository and its organization.
+
+* Documentation
+   Project techical documentation is under development along with the Ostro OS itself, and
+   can be found at https://ostroproject.org/documentation. 
+   Document sources are
+   stored within the meta-ostro GitHub repo for the Ostro Project.  The document sources are processed 
+   to generate the website documentation your currently reading but can also
+   be processed to generate a local website that can be read offline.
+
+* Issue Tracking with Jira
+   Requirements and Issue tracking is done with our public JIRA system at 
+   https://ostroproject.org/jira/.  You can browse through the issues freely,
+   but you'll need to create an account before submitting an issue of your own.
+   (Note that this Jira system will be available by the end of March 2016)
+
+* Mailing List
+   Mailing lists are a convenient way to communicate with Ostro project members as
+   well as other developers interested in the Ostro OS.  These lists are perhaps
+   the most convenient way to track developer discussions and to ask your own
+   support questions to the Ostro OS community.  Available mailing lists and how to subscribe
+   information is on https://lists.ostroproject.org.
+   You can also read through
+   the mailing list archives to follow past posts and discussions.
+
+* IRC Chatting
+   You can chat online with the Ostro OS developer community and other users in
+   our IRC channel ``#ostroproject`` on the freenode.net IRC server.  You can use
+   the http://webchat.freenode.net web client 
+   or use a client-side application
+   such as :command:`pidgin`.  Communication on IRC is immediate but transient,
+   making it good for meetings or a quick discussion.  (IRC discussions are
+   not recorded so it's better to use the mailing list for open discussions
+   with the community of developers.)

--- a/doc/quick_start/platforms.rst
+++ b/doc/quick_start/platforms.rst
@@ -5,7 +5,6 @@ Ostro |trade| OS Supported Platforms
 
 * `GigaByte GB-BXBT-3825 <http://iotsolutionsalliance.intel.com/solutions-directory/gb-bxbt-3825-iot-gateway-solution>`_
    a gateway solution powered by an Intel |reg| Atom |trade| E3825 dual-core processor 
-   (both 32-bit and 64-bit images are supported)
 
 * `Intel Galileo Gen2 <http://www.intel.com/content/www/us/en/embedded/products/galileo/galileo-overview.html>`_
    an Intel® Quark x1000 32-bit, single core, Intel Pentium |reg| Processor class
@@ -13,8 +12,7 @@ Ostro |trade| OS Supported Platforms
 
 * `MinnowBoard MAX <http://wiki.minnowboard.org>`_
    a MinnowBoard MAX-compatible board, featuring an Intel |reg| Atom |trade| E3826 1.46 GHz
-   Dual Core CPU, offering a compact, affordable, and powerful open hardware design 
-   (both 32-bit and 64-bit images are supported)
+   Dual Core CPU, offering a compact, affordable, and powerful open hardware design.
 
 * `Intel Edison <http://www.intel.com/content/www/us/en/do-it-yourself/edison.html>`_
    an ultra small Intel |reg| Atom |trade| SoC dual-core 32-bit CPU-based compute module aimed

--- a/doc/quick_start/quick_start.rst
+++ b/doc/quick_start/quick_start.rst
@@ -10,6 +10,10 @@ development system and to install and run applications on :ref:`platforms`.
 Refer to the Ostro OS Release Notes in the Image Release area for specific details about capabilities and status
 of features for the current release. 
 
+You'll find a summary of resources to find Ostro OS images, source code,
+documentation, and support systems in :ref:`access-support`
+
+
 This guide describes two ways to get started with your investigation and use of the Ostro OS: 
 
 * Download one of the pre-built Ostro OS images, ready to run on a supported hardware platform, or 
@@ -20,69 +24,6 @@ This guide describes two ways to get started with your investigation and use of 
 
 .. _`Yocto Project`: http://yoctoproject.org
 
-
-Access and Support
-==================
-
-Here’s a quick summary of resources to find Ostro OS images, source code,
-documentation, and support systems:
-
-* Ostro Project Website
-   The website https://ostroproject.org is the central source of  
-   information about the Ostro Project.  On this site you'll find current information
-   about the project as well as all the relevent links to project material 
-   (including these technical documents).
-
-* Image Releases
-   Pre-built Ostro OS images for all the :ref:`platforms` are available at
-   https://download.ostroproject.org
-
-   In there you’ll find an images folder with separate folders for each of
-   the supported hardware platforms. In the platform folder, you’ll find an
-   :file:`.dsk` file that can be written directly onto a hard disk or
-   USB thumb drive and booted.  There’s also a :file:`.vdi` file for use with VirtualBox.
-
-* Software Updates
-   The Ostro OS uses a rolling updates development and release process using "bundle"  
-   technology developed by the Clear Linux\* OS for Intel |reg| Architecture team.  You 
-   can read more about bundles at `Clear Linux Project Software Update`_
-
-.. _`Clear Linux Project Software Update`: https://clearlinux.org/features/software-update
-   
-* Source Code on GitHub
-   Ostro OS source code is maintained on a public GitHub repository at
-   https://github.com/ostroproject. Check out the README there for more information
-   about the repository and its organization.
-
-* Documentation
-   Project techical documentation is under development and the document sources are
-   stored along with the Ostro OS code on GitHub.  The document sources are processed 
-   to generate the website documentation your currently reading.
-
-* Issue Tracking with JIRA
-   Requirements and Issue tracking is done with our public JIRA system at 
-   https://ostroproject.org/jira/.  You can browse through the issues freely,
-   but you'll need to create an account before submitting an issue of your own.
-
-* Mailing List
-   Mailing lists are a convenient way to communicate with Ostro project members as
-   well as other developers interested in the Ostro OS.  These lists are perhaps
-   the most convenient way to track developer discussions and to ask your own
-   support questions to the Ostro OS community.  You can find a list of
-   the available mailing lists, how to subscribe, and what each list is used for
-   from https://lists.ostroproject.org
-   You can also read through
-   the mailing list archives to follow past posts and discussions.
-
-* IRC Chatting
-   You can chat online with the Ostro OS developer community and other users in
-   our IRC channel ``#ostroproject`` on the freenode.net IRC server.  You can use
-   the http://webchat.freenode.net web client 
-   or use a client-side application
-   such as :command:`pidgin`.  Communication on IRC is immediate but transient,
-   making it good for meetings or a quick discussion.  (IRC discussions are
-   not recorded so it's better to use the mailing list for open discussions
-   with the community of developers.)
 
 
 Prerequisites


### PR DESCRIPTION
Primarily an edit pass to fix spelling and ReST formatting
typos noticed in a walkthrough of the documentation site.

Also:
- added VirtualBox boot instructions to booting-and-installation.rst
  and verified the steps on a Windows system with the 365 dev .vdi image.
- separated "technical" and "process" notes in howtos.rst
- simplified and shortened quick_start by moving access and support
  information to a new access-support.rst
- removed "32- and 64-bit support" from platforms.rst
- added IRC information to access-support.rst and communication-guidelines.rst
- reported CSS style fix to DX team for the website theme issue
  causing a table in security-threat-analysis.rst to overflow

[skip ci]

Signed-off-by: David Kinder david.b.kinder@intel.com
