### PR TITLE
ostro.conf: Blacklist incompatible meta-intel-iot-middleware recipes

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -274,6 +274,15 @@ PNBLACKLIST[oprofileui-server] = "Has undesired machine-dependency"
 RDEPENDS_packagegroup-core-device-devel_remove_pn-packagegroup-core-device-devel = "oprofileui-server"
 RDEPENDS_packagegroup-core-tools-profile_remove_pn-packagegroup-core-tools-profile = "lttng-tools"
 
+# meta-intel-iot-middleware unbuildable or otherwise broken recipes
+PNBLACKLIST[libwyliodrin] = "Cannot be build due to blacklisted hiredis"
+PNBLACKLIST[wyliodrin-server] = "Cannot be build due to blacklisted jansson"
+PNBLACKLIST[hiredis] = "Depends on unavailable redis"
+PNBLACKLIST[xdk-daemon] = "Depends on unavailable libarchive-bin"
+PNBLACKLIST[parse-embedded-sdks] = "Invalid LICENSE format"
+PNBLACKLIST[python-pyfirmata] = "RDEPENDS on unavailable python-pyserial"
+PNBLACKLIST[python-serial] = "Cannot be built, not supported."
+
 # Disable certain components which are in meta-intel-iot-security, but
 # which we do not want in the image anymore.
 PNBLACKLIST[app-runas] = "obsolete"


### PR DESCRIPTION
iotsstatetests.SStateTests.test_sstate_samesigs oe-selftest reports
new problems in meta-intel-iot-middleware since the re-built of
ostro-os repository.

Blacklist incompatible meta-intel-iot-middleware recipes reported
by iotsstatetests.SStateTests.test_sstate_samesigs to gain PASS
again.

Signed-off-by: Mikko Ylinen mikko.ylinen@intel.com
