### PR TITLE
DOC: edits from pre-launch review

### DIFF
--- a/doc/howtos/doc-guidelines.rst
+++ b/doc/howtos/doc-guidelines.rst
@@ -25,24 +25,20 @@ Folder structure
 top-level doc directory
     index.rst "main page"
 
-howtos_
+howtos
     Articles explaining how to do certain tasks covering
     development on (or for) Ostro OS as well as using and contributing to it.
 
-architecture_
+architecture
     Technical Architecture information about the Ostro OS and its components
 
-quick_start_
+quick_start
     Getting Started Guide and associated subtopics for setting up Ostro OS development
 
 sphinx_build
     Sphinx configuration and build files for the Ostro Project's website.  When processed, 
     HTML output is contained within this folder in the _build/html folder.
 
-
-.. _howtos: howtos
-.. _architecture: architecture
-.. _quick_start: quick_start
 
 
 Headings

--- a/doc/quick_start/about.rst
+++ b/doc/quick_start/about.rst
@@ -22,8 +22,8 @@ Key features of Ostro OS include:
 * Linux* OS tailored for Internet of Things applications
 * Intel |reg| Quark |trade| and Intel |reg| Atom |trade| processor support
 * Application Framework support for Node.js, Python and C/C++ applications
-* RESTful APIs for System Status and OIC resource discovery
-* JavaScript APIs based on the `OIC specifications <https://github.com/ostroproject/iotivity-node/blob/master/spec/iot-js-spec.md>`_
+* RESTful APIs for System Status and `Open Connectivity Foundation <http://openconnectivity.org/>`_ (OCF) resource discovery
+* JavaScript APIs based on the `OCF specifications <https://github.com/otcshare/iotivity-node/blob/master/spec/iot-js-spec.md>`_
 * Security features: Trusted Boot, Applications Memory Isolation and 
   Impersonation Prevention, Integrity Verification
 * Rich set of communication and IoT interconnectivity for Bluetooth*/BLE, WiFi,


### PR DESCRIPTION
[skip ci]

howtos/doc-guidelines.rst
- removed links to folders in description of doc area layout

quick_start/about.rst
- changed references from OCI to OCF, added link to OCF
- fixed link to OCF specification accordingly

Signed-off-by: David Kinder <david.b.kinder@intel.com>