### PR TITLE
system-and-security-architecture.rst: remove TODO keyword

### DIFF
--- a/doc/architecture/system-and-security-architecture.rst
+++ b/doc/architecture/system-and-security-architecture.rst
@@ -235,17 +235,13 @@ users. It is not possible to set a root password.
 
 To become root in the core system:
 
-* After installation and before booting for the first time, add a
-  public key to the ``~root/.ssh/authorized_keys`` file (*TODO*:
-  create the directory and file with correct permissions, document
-  the exact location, which may vary between development and
-  production image)
+* Add a personal public key to the ``~root/.ssh/authorized_keys`` file,
+  then use ssh. There are different approaches for this (build-time
+  configuration option, modifying pre-built images, customizing a
+  running image) which are described in detail elsewhere.
 
-* \*Only in the development image\*: log in via a local console and or
-  serial port as root. A PAM module allows root to log in without
-  password. Because development and production image use different
-  signing keys (*TODO*), that module and its configuration cannot be
-  copied from a development image to a production image.
+* \*Only in the development image\*: root automatically gets logged in
+  on a local console or serial port.
 
 Most groups are used to control access to certain resources like
 files, devices or privileged operations in system daemons. Device node

--- a/doc/architecture/system-and-security-architecture.rst
+++ b/doc/architecture/system-and-security-architecture.rst
@@ -256,7 +256,7 @@ Unix Group   Resource
 *TODO*: adm  operations typically reserved for root, like rebooting and starting/stopping systemd services
 audio        audio devices
 video        video devices
-rfkill       ``/dev/rfkill`` (*TODO* - patch pending in pohly/ostro/passwd)
+rfkill       ``/dev/rfkill``
 ============ ===============================================================================================
 
 
@@ -331,8 +331,8 @@ System Updates
 Ostro OS binaries are delivered as bundles, as in the Clear Linux OS.
 Bundles are a bit like traditional packages, but can overlap with
 other bundles and come with less metadata. Instead of thousands of
-packages, the entire distro consists of about 10 to 20 (*TODO*:
-double-check this guess) bundles. There is a core bundle with all the
+packages, the entire distro consists of about 10 to 20 bundles.
+There is a core bundle with all the
 essential files required to boot the system. Several optional bundles
 contain individual runtimes and applications that were built together
 with the OS.

--- a/doc/architecture/system-and-security-architecture.rst
+++ b/doc/architecture/system-and-security-architecture.rst
@@ -48,7 +48,8 @@ applications. All interaction with the device is done
 through applications, not by logging into the core system directly.
 
 This architecture documentation explains how the security is currently
-integrated into the Ostro OS. Especially covered are the
+integrated into the Ostro OS. Some items that may be added are also
+documented, but clearly marked as *TODO*. Especially covered are the
 places where the security model differs from baseline Linux security
 that can be expected from any mainstream desktop Linux distribution.
 
@@ -75,7 +76,7 @@ Key Security Concepts
   bits as intended to prevent that. Because applications are trusted,
   this is acceptable. When that is undesirable or to mitigate
   risks when applications get compromised, optionally Smack as a MAC
-  mechanism can be used to separate applications further.
+  mechanism can be used to separate applications further (*TODO*).
 
 * Namespaces and containers further restrict what applications can
   access and do.
@@ -102,7 +103,7 @@ Boot Process + Secure Boot
 
    b) when using IMA with EVM, and booting for the first time, it is
       necessary to personalize the EVM protection to the current
-      device; more on that below.
+      device (*TODO*); more on that below.
 
    c) if used, IMA/EVM policy gets activated
 
@@ -186,13 +187,15 @@ the same writable partition.
 ``/``
   Includes everything that is not explicitly listed
   below. Conceptually this is read-only and will only be mounted
-  read/write during system software updates Currently / is mounted 
-  read/write all the time but all services
+  read/write during system software updates (*TODO*: in practice,
+  currently / is mounted read/write all the time but all services
   except software update use systemd's ``ProtectSystem=full`` to make the
-  root filesystem appear read-only to them. The goal is to have all files 
-  signed using IMA hashes. The IMA policy may be updated in future builds
-  to provide a clean separation
-  between read-only and read/write files in different partitions.
+  root filesystem appear read-only to them). All files are using
+  signed IMA hashes and thus cannot be modified on the device (*TODO*:
+  because we have not finished the transition to a clean separation
+  between read-only and read/write files in different partitions, the
+  current IMA policy also allows hashes created on the device, which
+  allows circumventing the offline protection).
 
 ``/var``
   Persistent data which can be written on the device. Protected by
@@ -211,13 +214,16 @@ the same writable partition.
 
 ``/etc/ld.so.cache``
   Its content depends on the currently installed shared libraries,
-  which may vary by device. In future builds it will be updated on the
-  device after system software installation or updates. 
+  which may vary by device. Therefore it needs to be updated on the
+  device after system software installation or updates. Its real
+  location thus is in /var (*TODO*).
 
 ``/etc/machine-id``
   Currently systemd creates a machine ID when booting and writes it to
-  ``/etc/machine-id`` when ``/etc`` becomes writeable. In future builds
-  this can be updated as per the IMA policy. 
+  ``/etc/machine-id`` when ``/etc`` becomes writeable. When moving to the strict
+  IMA policy, we need to prevent that (because the file would become
+  unreadable, which breaks several systemd services) or move it to ``/var``
+  (*TODO*).
 
 
 User, Group and Privilege Management
@@ -230,18 +236,32 @@ users. It is not possible to set a root password.
 To become root in the core system:
 
 * After installation and before booting for the first time, add a
-  public key to the ``~root/.ssh/authorized_keys`` file.
+  public key to the ``~root/.ssh/authorized_keys`` file (*TODO*:
+  create the directory and file with correct permissions, document
+  the exact location, which may vary between development and
+  production image)
 
-* \*In the development image\*: log in via a local console or
-  serial port as root. A PAM module allows root to log in without a
-  password. The development and production image use different
-  signing keys so PAM module and its configuration cannot be
+* \*Only in the development image\*: log in via a local console and or
+  serial port as root. A PAM module allows root to log in without
+  password. Because development and production image use different
+  signing keys (*TODO*), that module and its configuration cannot be
   copied from a development image to a production image.
 
 Most groups are used to control access to certain resources like
 files, devices or privileged operations in system daemons. Device node
 ownerships are set using udev rules, similar to how ``audio`` and
 ``video`` are handled in traditional Linux desktop systems.
+
+Here is a list of existing groups and the corresponding resources:
+
+============ ===============================================================================================
+Unix Group   Resource
+============ ===============================================================================================
+*TODO*: adm  operations typically reserved for root, like rebooting and starting/stopping systemd services
+audio        audio devices
+video        video devices
+rfkill       ``/dev/rfkill`` (*TODO* - patch pending in pohly/ostro/passwd)
+============ ===============================================================================================
 
 
 Process Handling
@@ -314,8 +334,9 @@ System Updates
 
 Ostro OS binaries are delivered as bundles, as in the Clear Linux OS.
 Bundles are a bit like traditional packages, but can overlap with
-other bundles and come with less metadata. 
-There is a core bundle with all the
+other bundles and come with less metadata. Instead of thousands of
+packages, the entire distro consists of about 10 to 20 (*TODO*:
+double-check this guess) bundles. There is a core bundle with all the
 essential files required to boot the system. Several optional bundles
 contain individual runtimes and applications that were built together
 with the OS.
@@ -336,6 +357,8 @@ against older revisions of the bundles are calculated and published on
 a download server. The Clear OS swupd tool is then responsible for
 downloading the deltas and applying them to the local copy of the
 bundles.
+
+(*TODO*): write more about signature handling, how swupd is run, etc.
 
 
 Core OS Hardening
@@ -431,12 +454,12 @@ IMA signing key               Product-specific, secret         Published togethe
                                                                source code
 swupd signature validation    TBD
 ----------------------------- ---------------------------------------------------------------------------
-Kernel debug interfaces       Disabled                         Enabled 
+Kernel debug interfaces       Disabled                         Enabled (*TODO*: document)
 Root password                 Not set
 ----------------------------- ---------------------------------------------------------------------------
 Local login as root           Disabled                         Enabled for console (tty) and serial port,
                                                                automatic login
-SSH                           Installed, but disabled          Installed and running, but authorized keys
+SSH                           Installed, but disabled (*TODO*) Installed and running, but authorized keys
                                                                must be set up before it becomes usable
 ============================= ================================ ==========================================
 

--- a/doc/architecture/system-and-security-architecture.rst
+++ b/doc/architecture/system-and-security-architecture.rst
@@ -48,10 +48,18 @@ applications. All interaction with the device is done
 through applications, not by logging into the core system directly.
 
 This architecture documentation explains how the security is currently
-integrated into the Ostro OS. Some items that may be added are also
-documented, but clearly marked as *TODO*. Especially covered are the
+integrated into the Ostro OS. Especially covered are the
 places where the security model differs from baseline Linux security
 that can be expected from any mainstream desktop Linux distribution.
+Where necessary for the understandig of the architecture, future work
+and enhancements are described, but in such a way that it is possible
+to determine what the current Ostro OS already provides.
+
+.. TODO: annotations about planned changes for text or future work
+   items can be called out in "TODO" comments. These comments then
+   (intentionally!) are not visible the HTML version of the document.
+   When describing future work in the visible text, prefer future
+   tense ("will be implemented") over negations ("not implemented yet").
 
 For a discussion of potential other security mechanisms see the
 :ref:`security-threat-analysis` documentation.
@@ -76,7 +84,9 @@ Key Security Concepts
   bits as intended to prevent that. Because applications are trusted,
   this is acceptable. When that is undesirable or to mitigate
   risks when applications get compromised, optionally Smack as a MAC
-  mechanism can be used to separate applications further (*TODO*).
+  mechanism will be supported to separate applications further. At the
+  moment, Smack is integrated into Ostro OS and enabled at runtime,
+  but the application framework does not use it.
 
 * Namespaces and containers further restrict what applications can
   access and do.
@@ -103,7 +113,8 @@ Boot Process + Secure Boot
 
    b) when using IMA with EVM, and booting for the first time, it is
       necessary to personalize the EVM protection to the current
-      device (*TODO*); more on that below.
+      device; more on that below. This step will be implemented in
+      the future. Right now, EVM is not used at all.
 
    c) if used, IMA/EVM policy gets activated
 
@@ -187,11 +198,11 @@ the same writable partition.
 ``/``
   Includes everything that is not explicitly listed
   below. Conceptually this is read-only and will only be mounted
-  read/write during system software updates (*TODO*: in practice,
+  read/write during system software updates (in practice,
   currently / is mounted read/write all the time but all services
   except software update use systemd's ``ProtectSystem=full`` to make the
   root filesystem appear read-only to them). All files are using
-  signed IMA hashes and thus cannot be modified on the device (*TODO*:
+  signed IMA hashes and thus cannot be modified on the device (
   because we have not finished the transition to a clean separation
   between read-only and read/write files in different partitions, the
   current IMA policy also allows hashes created on the device, which
@@ -209,21 +220,14 @@ the same writable partition.
   home directory with access limited to the application.
 
 ``/etc``
-  The files in it are part of the core OS and thus considered
-  read-only. However, there are a few noteworthy exceptions:
+  Ostro OS will become a "stateless" distribution, which means that
+  all system default configuration files will be stored under ``/usr``
+  and ``/etc`` is empty before the first boot. ``/etc/`` will be writable
+  and protected like ``/var``. In this model, ``/etc`` is reserved for
+  changes made by a device administrator and its content will be read
+  and used, but typically never modified by the system.
 
-``/etc/ld.so.cache``
-  Its content depends on the currently installed shared libraries,
-  which may vary by device. Therefore it needs to be updated on the
-  device after system software installation or updates. Its real
-  location thus is in /var (*TODO*).
-
-``/etc/machine-id``
-  Currently systemd creates a machine ID when booting and writes it to
-  ``/etc/machine-id`` when ``/etc`` becomes writeable. When moving to the strict
-  IMA policy, we need to prevent that (because the file would become
-  unreadable, which breaks several systemd services) or move it to ``/var``
-  (*TODO*).
+  .. TODO: add link to `stateless` architecture document once it is available.
 
 
 User, Group and Privilege Management
@@ -253,7 +257,9 @@ Here is a list of existing groups and the corresponding resources:
 ============ ===============================================================================================
 Unix Group   Resource
 ============ ===============================================================================================
-*TODO*: adm  operations typically reserved for root, like rebooting and starting/stopping systemd services
+adm          operations typically reserved for root, like rebooting and starting/stopping systemd services
+             (will be implemented in the future, right now applications cannot trigger privileged
+             operations)
 audio        audio devices
 video        video devices
 rfkill       ``/dev/rfkill``
@@ -354,7 +360,7 @@ a download server. The Clear OS swupd tool is then responsible for
 downloading the deltas and applying them to the local copy of the
 bundles.
 
-(*TODO*): write more about signature handling, how swupd is run, etc.
+For more information about swupd, see :ref:`software-update`.
 
 
 Core OS Hardening
@@ -450,13 +456,13 @@ IMA signing key               Product-specific, secret         Published togethe
                                                                source code
 swupd signature validation    TBD
 ----------------------------- ---------------------------------------------------------------------------
-Kernel debug interfaces       Disabled                         Enabled (*TODO*: document)
+Kernel debug interfaces       Disabled                         Disabled (may get enabled in the future)
 Root password                 Not set
 ----------------------------- ---------------------------------------------------------------------------
 Local login as root           Disabled                         Enabled for console (tty) and serial port,
                                                                automatic login
-SSH                           Installed, but disabled (*TODO*) Installed and running, but authorized keys
-                                                               must be set up before it becomes usable
+SSH                           Installed and running (will be   Installed and running, but authorized keys
+                              disabled)                        must be set up before it becomes usable
 ============================= ================================ ==========================================
 
 For more information about signing, see the :ref:`certificate-handling` how-to tech note.

--- a/doc/howtos/howtos.rst
+++ b/doc/howtos/howtos.rst
@@ -20,6 +20,7 @@ Technical Notes
    uefi-secure-boot
    certificate-handling
    software-update-server
+   firewall-configuration
 
 Process Notes
 =============


### PR DESCRIPTION
Having "TODO" in the documentation was called out as a release
blocker. Let's use this PR to discuss how we can handle that properly.

[skip ci]