### PR TITLE
DOC: more review edits

### DIFF
--- a/doc/architecture/application-framework.rst
+++ b/doc/architecture/application-framework.rst
@@ -22,7 +22,8 @@ Framework
 The Application Framework has two actual components: an
 installer and a systemd generator. The details of the installer are
 still open, since it is undecided in which format 3rd-party
-applications will be delivered. At least `Clear Linux\* bundles`_  
+applications will be delivered. At least 
+`bundles`_ (from the Clear Linux\* OS for Intel |reg| Architecture project)
 and `XDG-APPs`_ are being considered
 as alternatives. In either case, the
 installer will be a simple wrapper script with minimal additional
@@ -32,7 +33,8 @@ application (in the eventually chosen format).
 The systemd generator component produces systemd service files for the
 applications using information from the application manifest.
 
-.. _Clear Linux\* bundles: https://clearlinux.org/documentation/index_bundles.html
+
+.. _bundles: https://clearlinux.org/documentation/index_bundles.html
 .. _XDG-APPs: https://wiki.gnome.org/Projects/SandboxedApps
 
 

--- a/doc/architecture/architecture.rst
+++ b/doc/architecture/architecture.rst
@@ -3,7 +3,11 @@
 Ostro |trade| OS Architecture
 ##################################
 
-These documents provide descriptions of the Ostro |trade| OS 
+The Ostro OS is a Linux*-based operating system tailored for IoT devices and built with
+security in mind.  Ostro OS is based on standard libraries and services with 
+frameworks to help with best practices and common IoT use cases.
+
+The following documents start off our descriptions of the Ostro |trade| OS 
 components and their relationships so developers
 can learn more technical details about what we're building.
 

--- a/doc/architecture/efi-boot.rst
+++ b/doc/architecture/efi-boot.rst
@@ -68,4 +68,4 @@ Disadvantages
   of an additional EFI binary or the implementation of an EFI shell script.
   This sort of expertise might not be very common among Ostro OS developers.
 - Changing the contents of the command line requires rebuilding the EFI combo,
-  unless there is a mechanism in place to support an alternative (to be developed).
+  unless there is a mechanism in place to support an alternative.

--- a/doc/architecture/security-threat-analysis.rst
+++ b/doc/architecture/security-threat-analysis.rst
@@ -188,7 +188,14 @@ Applications and services running on user device Elevation of privilege       Ap
 Cloud service, other trusted devices             Data modification            Application and     Attack on the
                                                                               system data         remote device
                                                                                                   or service
+Bluetooth, other connectivity services           Data confidentiality,        Application and     Network attack,
+                                                 Data integrity               network data        malformed input                        
 ================================================ ============================ =================== =================
+
+Note that Ostro OS also includes a variety of mechanisms intended for
+developer use and debugging.  While we have attempted to show developers how
+to use these modes of access in the safest method possible, they could be
+used as additional attack surfaces if left open in final products.
 
 Threats
 -------
@@ -623,3 +630,4 @@ Threats and Attack Vectors Out of Scope for Ostro OS 1.0 Release
   to overheat
 * attack vectors based on hardware that is specific to
   certain devices (like USB ports)
+* attack vectors caused by debug modes left enabled in final products

--- a/doc/architecture/software-update.rst
+++ b/doc/architecture/software-update.rst
@@ -44,7 +44,7 @@ Software Update Client
 ======================
 
 The client runs on the device and is responsible of downloading, verifying
-(signature verification to be implemented) and applying the updates.
+and applying the updates.
 It can also restore modified files to their pristine state as then were in the
 initial sw image.
 
@@ -62,10 +62,8 @@ a bare-bones working system.
 Everything else is optional and can be either deployed or removed by using the
 software update client program.
 
-Ostro OS developers can also use bundles if they follow the rule that each application is
+Ostro OS developers can also use bundles by following the rule that each application is
 contained in its own bundle.
 
 .. _bundles: https://clearlinux.org/documentation/bundles_overview.html
 
-XXX TODO: add here or in the howto some info on how to create bundles, once that part
-is working.

--- a/doc/architecture/system-and-security-architecture.rst
+++ b/doc/architecture/system-and-security-architecture.rst
@@ -48,8 +48,7 @@ applications. All interaction with the device is done
 through applications, not by logging into the core system directly.
 
 This architecture documentation explains how the security is currently
-integrated into the Ostro OS. Some items that may be added are also
-documented, but clearly marked as *TODO*. Especially covered are the
+integrated into the Ostro OS. Especially covered are the
 places where the security model differs from baseline Linux security
 that can be expected from any mainstream desktop Linux distribution.
 
@@ -76,7 +75,7 @@ Key Security Concepts
   bits as intended to prevent that. Because applications are trusted,
   this is acceptable. When that is undesirable or to mitigate
   risks when applications get compromised, optionally Smack as a MAC
-  mechanism can be used to separate applications further (*TODO*).
+  mechanism can be used to separate applications further.
 
 * Namespaces and containers further restrict what applications can
   access and do.
@@ -103,7 +102,7 @@ Boot Process + Secure Boot
 
    b) when using IMA with EVM, and booting for the first time, it is
       necessary to personalize the EVM protection to the current
-      device (*TODO*); more on that below.
+      device; more on that below.
 
    c) if used, IMA/EVM policy gets activated
 
@@ -187,15 +186,13 @@ the same writable partition.
 ``/``
   Includes everything that is not explicitly listed
   below. Conceptually this is read-only and will only be mounted
-  read/write during system software updates (*TODO*: in practice,
-  currently / is mounted read/write all the time but all services
+  read/write during system software updates Currently / is mounted 
+  read/write all the time but all services
   except software update use systemd's ``ProtectSystem=full`` to make the
-  root filesystem appear read-only to them). All files are using
-  signed IMA hashes and thus cannot be modified on the device (*TODO*:
-  because we have not finished the transition to a clean separation
-  between read-only and read/write files in different partitions, the
-  current IMA policy also allows hashes created on the device, which
-  allows circumventing the offline protection).
+  root filesystem appear read-only to them. The goal is to have all files 
+  signed using IMA hashes. The IMA policy may be updated in future builds
+  to provide a clean separation
+  between read-only and read/write files in different partitions.
 
 ``/var``
   Persistent data which can be written on the device. Protected by
@@ -214,16 +211,13 @@ the same writable partition.
 
 ``/etc/ld.so.cache``
   Its content depends on the currently installed shared libraries,
-  which may vary by device. Therefore it needs to be updated on the
-  device after system software installation or updates. Its real
-  location thus is in /var (*TODO*).
+  which may vary by device. In future builds it will be updated on the
+  device after system software installation or updates. 
 
 ``/etc/machine-id``
   Currently systemd creates a machine ID when booting and writes it to
-  ``/etc/machine-id`` when ``/etc`` becomes writeable. When moving to the strict
-  IMA policy, we need to prevent that (because the file would become
-  unreadable, which breaks several systemd services) or move it to ``/var``
-  (*TODO*).
+  ``/etc/machine-id`` when ``/etc`` becomes writeable. In future builds
+  this can be updated as per the IMA policy. 
 
 
 User, Group and Privilege Management
@@ -236,32 +230,18 @@ users. It is not possible to set a root password.
 To become root in the core system:
 
 * After installation and before booting for the first time, add a
-  public key to the ``~root/.ssh/authorized_keys`` file (*TODO*:
-  create the directory and file with correct permissions, document
-  the exact location, which may vary between development and
-  production image)
+  public key to the ``~root/.ssh/authorized_keys`` file.
 
-* \*Only in the development image\*: log in via a local console and or
-  serial port as root. A PAM module allows root to log in without
-  password. Because development and production image use different
-  signing keys (*TODO*), that module and its configuration cannot be
+* \*In the development image\*: log in via a local console or
+  serial port as root. A PAM module allows root to log in without a
+  password. The development and production image use different
+  signing keys so PAM module and its configuration cannot be
   copied from a development image to a production image.
 
 Most groups are used to control access to certain resources like
 files, devices or privileged operations in system daemons. Device node
 ownerships are set using udev rules, similar to how ``audio`` and
 ``video`` are handled in traditional Linux desktop systems.
-
-Here is a list of existing groups and the corresponding resources:
-
-============ ===============================================================================================
-Unix Group   Resource
-============ ===============================================================================================
-*TODO*: adm  operations typically reserved for root, like rebooting and starting/stopping systemd services
-audio        audio devices
-video        video devices
-rfkill       ``/dev/rfkill`` (*TODO* - patch pending in pohly/ostro/passwd)
-============ ===============================================================================================
 
 
 Process Handling
@@ -334,9 +314,8 @@ System Updates
 
 Ostro OS binaries are delivered as bundles, as in the Clear Linux OS.
 Bundles are a bit like traditional packages, but can overlap with
-other bundles and come with less metadata. Instead of thousands of
-packages, the entire distro consists of about 10 to 20 (*TODO*:
-double-check this guess) bundles. There is a core bundle with all the
+other bundles and come with less metadata. 
+There is a core bundle with all the
 essential files required to boot the system. Several optional bundles
 contain individual runtimes and applications that were built together
 with the OS.
@@ -358,23 +337,16 @@ a download server. The Clear OS swupd tool is then responsible for
 downloading the deltas and applying them to the local copy of the
 bundles.
 
-(*TODO*): write more about signature handling, how swupd is run, etc.
-
 
 Core OS Hardening
 =================
 
-*TODO*: describe compiler flags
+In future builds, these additional features will be considered for Core OS hardening:
 
-*TODO*: noexec tmpfs mounts
-
-*TODO*: list daemons running as non-root and how that was achieved (ambient capabilities, rfkill group for connman)
-
-*TODO*: instructions how to deal with services needing to talk with each other, D-Bus policies etc.
-
-*TODO*: Recommended systemd options for services.
-
-*TODO*: Security processes followed by Ostro OS? Information about found vulnerabilities etc.
+- noexec tmpfs mounts
+- running daemons as non-root (e.g., ambient capabilities, rfkill group for connman)
+- dealing with services needing to talk with each other, D-Bus policies etc.
+- systemd options for services.
 
 
 Network Security
@@ -442,12 +414,6 @@ security or interfere with the operation of other services or applications.
 Ostro OS does not have a centralized firewall control, so the service writers
 must be careful about this.
 
-*TODO*: instructions for replacing the default firewall ruleset
-
-*TODO*: sensor security
-
-*TODO*: system provisioning and first boot security
-
 
 Production and Development Images
 =================================
@@ -491,12 +457,12 @@ IMA signing key               Product-specific, secret         Published togethe
                                                                source code
 swupd signature validation    TBD
 ----------------------------- ---------------------------------------------------------------------------
-Kernel debug interfaces       Disabled                         Enabled (*TODO*: document)
+Kernel debug interfaces       Disabled                         Enabled 
 Root password                 Not set
 ----------------------------- ---------------------------------------------------------------------------
 Local login as root           Disabled                         Enabled for console (tty) and serial port,
                                                                automatic login
-SSH                           Installed, but disabled (*TODO*) Installed and running, but authorized keys
+SSH                           Installed, but disabled          Installed and running, but authorized keys
                                                                must be set up before it becomes usable
 ============================= ================================ ==========================================
 

--- a/doc/howtos/software-update-server.rst
+++ b/doc/howtos/software-update-server.rst
@@ -9,11 +9,11 @@ used to make software updates work with the Ostro OS.
 Prerequisites
 =============
 
- - a Linux host with Docker (>= 1.9.1), util-linux and rsync installed (Fedora 23 and
-   OpenSUSE 13.2 are known to work well for this purpose, but the outdated
-   Docker packages in Ubuntu 14.04 might have connectivity issues);
- - signing keys (alternatively testing keys from the :file:`swupd-server` project can
-   be used).
+- a Linux host with Docker (>= 1.9.1), util-linux and rsync installed (Fedora 23 and
+  OpenSUSE 13.2 are known to work well for this purpose, but the outdated
+  Docker packages in Ubuntu 14.04 might have connectivity issues);
+- signing keys (alternatively testing keys from the :file:`swupd-server` project can
+  be used).
 
 Creating a Docker Image
 =======================
@@ -49,7 +49,8 @@ you'd need to add something like "--dns 8.8.8.8 --dns 8.8.4.4" to the
 Creating a Software Update Repo
 ===============================
 
-The main selling point of Clear Linux's software updates (which we're using for
+The main selling point of Clear Linux\* OS for Intel |reg| Architecture's 
+software updates (which we're using for
 Ostro OS software updates), is the per-file update
 granularity and the ability to use binary deltas for updates. But this
 comes at a price: previous builds need to be preserved in order to
@@ -65,7 +66,8 @@ Here is a script that will extract the contents of the latest rootfs:
    :language: sh 
 
 
-(There's a copy of this script saved as :file:`extract_rootfs.sh`.) 
+(There's a copy of this :file:`extract_rootfs.sh` script in the ostroproject
+`GitHub repository <https://github.com/ostroproject/ostro-os/blob/master/doc/howtos/extras/extract_rootfs.sh>`_.) 
 
 Do the following steps to setup your swupd server repository:
 

--- a/doc/quick_start/access-support.rst
+++ b/doc/quick_start/access-support.rst
@@ -42,11 +42,11 @@ documentation, and support systems:
    to generate the website documentation your currently reading but can also
    be processed to generate a local website that can be read offline.
 
-* Issue Tracking with Jira
-   Requirements and Issue tracking is done with our public JIRA system at 
-   https://ostroproject.org/jira/.  You can browse through the issues freely,
-   but you'll need to create an account before submitting an issue of your own.
-   (Note that this Jira system will be available by the end of March 2016)
+* Issue Reporting and Tracking
+   Requirements and Issue tracking is done for now using GitHub issues here:
+   https://github.com/ostroproject/ostro-os/issues  You can browse through the reported issues
+   and submit issues of your own.
+  
 
 * Mailing List
    Mailing lists are a convenient way to communicate with Ostro project members as

--- a/doc/sphinx_build/conf.py
+++ b/doc/sphinx_build/conf.py
@@ -315,7 +315,7 @@ html_context = {
 # For sphinx.ext.extlinks, setup some common shortcuts
 #   :issue:`123` inserts a link to IOTOS-123 in Jira
 #
-extlinks = {'issue': ('https://jira01.devtools.intel.com/browse/IOTOS-%s',
-                      'IOTOS-')
+extlinks = {'issue': ('https://ostroproject.org/jira/browse/OP-%s',
+                      'OP-')
            
            }


### PR DESCRIPTION
Cleaned up TODO items
Changed Jira references to use GitHub issues
some more formatting issues fixed

security-threat-analysis: (from Teri Oda)
- clarifying that debug modes
  could be used as an additional attack vector if not disabled in
  final products and adding debug to the out-of-scope section.
- Added bluetooth explicitly to attack surfaces

conf.py
- removed references to old jira in substition macro (not used yet)

Signed-off-by: David Kinder <david.b.kinder@intel.com>