### PR TITLE
Enable Soletta C tests and FBP tests as ptest:

### DIFF
--- a/meta-ostro/recipes-soletta/soletta/files/add-fbp-passfail-result.patch
+++ b/meta-ostro/recipes-soletta/soletta/files/add-fbp-passfail-result.patch
@@ -1,0 +1,35 @@
+Add PASS/FAIL output to test output
+Fix tools/run-fbp-tests bug #1516. Once the upstream patch integrated, this fixing will be dropped.
+
+---
+diff --git a/tools/run-fbp-tests b/tools/run-fbp-tests
+index 6bb618d..0ebe0e7 100755
+--- a/tools/run-fbp-tests
++++ b/tools/run-fbp-tests
+@@ -241,6 +241,7 @@ def run_tests(args):
+         if curr.should_skip(skips):
+             logging.debug("SKIPPED running %s: %s" % (t, curr.skip_msg))
+             status["skipped"] += 1
++            logging.info("SKIP: %s" % path["file"])
+             continue
+ 
+         if not args.compiled:
+@@ -269,6 +270,7 @@ def run_tests(args):
+                 logging.warning("Dependence test %s for test %s failed. Skipping it",
+                         curr.depends, curr.test_file)
+                 status["skipped"] += 1
++                logging.info("FAIL: %s" % path["file"])
+                 continue
+ 
+             out, code = sh(cmd, cwd=test_cwd)
+@@ -277,8 +279,10 @@ def run_tests(args):
+         status[result] += 1
+         if result == "failed":
+             failures = True
++            logging.info("FAIL: %s" % path["file"])
+         else:
+             successful.append(path['file'])
++            logging.info("PASS: %s" % path["file"])
+ 
+     for k,v in status.items():
+         if v > 0:

--- a/meta-ostro/recipes-soletta/soletta/files/run-ptest
+++ b/meta-ostro/recipes-soletta/soletta/files/run-ptest
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+SOLETTA_C_TEST_RUNNER=suite.py
+SOLETTA_FBP_TEST_RUNNER=run-fbp-tests
+
+echo "=== Run Soletta C test cases ==="
+C_TEST_PASS_COUNTER=0
+C_TEST_FAIL_COUNTER=0
+C_TEST_SKIP_COUNTER=0
+C_TEST_DIR="src/test"
+
+cd $C_TEST_DIR
+# not use suite.py because the output might be messed and not compitable to ptest log format
+# inestigate how to fix this in suite.py
+# python $SOLETTA_FBP_TEST_RUNNER --tests="$(find ./ -executable -type f)"
+
+for tc in $(ls | grep -v ".log"); do
+    timeout 30 ./$tc
+    case $? in
+      0)
+        echo "PASS: $tc"
+        C_TEST_PASS_COUNTER=$((C_TEST_PASS_COUNTER+1))
+        ;;
+      124)
+        echo "FAIL: $tc"
+        echo "$tc timeout"
+        C_TEST_SKIP_COUNTER=$((C_TEST_SKIP_COUNTER+1))
+        ;;
+      *)
+        echo "FAIL: $tc"
+        echo "$tc return non-zero"
+        C_TEST_FAIL_COUNTER=$((C_TEST_FAIL_COUNTER+1))
+        ;;
+    esac
+done
+echo "Summary: Soletta C Test"
+echo "         Case PASS: $C_TEST_PASS_COUNTER"
+echo "         Case FAIL: $C_TEST_FAIL_COUNTER"
+cd -
+
+echo "=== Run Soletta fbp test cases ==="
+python $SOLETTA_FBP_TEST_RUNNER --runner "/usr/bin/sol-fbp-runner" --log "DEBUG" 
+

--- a/meta-ostro/recipes-soletta/soletta/soletta-ptest.inc
+++ b/meta-ostro/recipes-soletta/soletta/soletta-ptest.inc
@@ -1,0 +1,19 @@
+inherit ptest
+
+SRC_URI += "file://run-ptest \
+            file://add-fbp-passfail-result.patch \
+           "
+
+do_compile_ptest() {
+        oe_runmake CFLAGS="--sysroot=${STAGING_DIR_TARGET} -pthread -lpcre" TARGETCC="${CC}" TARGETAR="${AR}" "tests"
+
+}
+do_install_ptest () {
+        mkdir -p ${D}/${PTEST_PATH}/src
+        cp -rf ${S}/build/stage/test ${D}/${PTEST_PATH}/src/
+        cp -f ${S}/data/scripts/suite.py ${D}/${PTEST_PATH}
+        cp -rf ${S}/src/test-fbp ${D}/${PTEST_PATH}/src/
+        cp -f ${S}/tools/run-fbp-tests ${D}/${PTEST_PATH}
+
+}
+

--- a/meta-ostro/recipes-soletta/soletta/soletta_%.bbappend
+++ b/meta-ostro/recipes-soletta/soletta/soletta_%.bbappend
@@ -9,3 +9,5 @@ INSANE_SKIP_${PN}-dev += "dev-elf"
 do_configure_prepend() {
     cp ${WORKDIR}/config ${S}/.config
 }
+
+require soletta-ptest.inc


### PR DESCRIPTION
    add inc file and update bbapend file for Soletta C/FBP test files compiling and installation
    patch fbp-run-tests to meet the ptest result output format
    add run-ptest as ptest execution entry

Signed-off-by: Lei Yang <lei.a.yang@intel.com>