### PR TITLE
clr-systemd-config_98.bb: fix broken LIC_FILES_CHKSUM

### DIFF
--- a/meta-ostro/recipes-swupd/clr-systemd-config/clr-systemd-config_98.bb
+++ b/meta-ostro/recipes-swupd/clr-systemd-config/clr-systemd-config_98.bb
@@ -1,5 +1,5 @@
 LICENSE = "LGPLv2.1"
-LIC_FILES_CHKSUM = "files://LICENSE;md5=4fbd65380cdd255951079008b364516c"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=4fbd65380cdd255951079008b364516c"
 
 SUMMARY = "Clear systemd config files for swupd"
 


### PR DESCRIPTION
"files://" is not the right method for finding the
license file. Correct is "file://".

"files://" no longer works with recent OE-core/bitbake, leading to:

ERROR: ExpansionError during parsing ..../clr-systemd-config_98.bb: Failure expanding variable do_fetch[file-checksums], expression was ${@bb.fetch.get_checksum_file_list(d)}  ${@get_lic_checksum_file_list(d)} which triggered exception IndexError: string index out of range

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>