### PR TITLE
systemd: port gummiboot cmdline patch

### DIFF
--- a/meta-ostro/recipes-core/systemd/systemd/0001-Workaround-remove-handling-of-custom-cmdline.patch
+++ b/meta-ostro/recipes-core/systemd/systemd/0001-Workaround-remove-handling-of-custom-cmdline.patch
@@ -1,26 +1,23 @@
-From f940fffe1ce00ba6dc1db62e12fea662a7ffc947 Mon Sep 17 00:00:00 2001
-From: Mikko Ylinen <mikko.ylinen@intel.com>
-Date: Wed, 24 Feb 2016 14:12:37 +0200
+From 3fda784f9d772abda1933512e4420f2547f0b4cc Mon Sep 17 00:00:00 2001
+From: Igor Stoppa <igor.stoppa@intel.com>
+Date: Thu, 5 Nov 2015 16:33:53 +0200
 Subject: [PATCH] Workaround: remove handling of custom cmdline
 
-When the BIOS is not in secure mode, the stub tries to load
-an alternate command line. However, on certain boxes, this
-backfires and wipes the default command line, even if an
-alternate is not available.
+When the BIOS is not in secure mode, the stub tries
+to load an alternate command line.
+However, on certain boxes, this backfires and wipes the default
+command line, even if an alternate is not available.
 
-Upstream-Status: Inapproriate
-
-Signed-off-by: Igor Stoppa <igor.stoppa@intel.com>
-Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>
+For now, remove the code.
 ---
- src/boot/efi/stub.c |   14 --------------
- 1 file changed, 14 deletions(-)
+ src/boot/efi/stub.c | 26 --------------
+ 1 file changed, 26 deletions(-)
 
 diff --git a/src/boot/efi/stub.c b/src/boot/efi/stub.c
-index 2cd5c33..2737fe7 100644
+index 1e250f3..a22e3b1 100644
 --- a/src/boot/efi/stub.c
 +++ b/src/boot/efi/stub.c
-@@ -87,20 +87,6 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+@@ -86,32 +86,6 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
  
          cmdline_len = szs[0];
  
@@ -36,11 +33,20 @@ index 2cd5c33..2737fe7 100644
 -                for (i = 0; i < cmdline_len; i++)
 -                        line[i] = options[i];
 -                cmdline = line;
+-
+-#ifdef SD_BOOT_LOG_TPM
+-                /* Try to log any options to the TPM, escpecially manually edited options */
+-                err = tpm_log_event(SD_TPM_PCR,
+-                                    (EFI_PHYSICAL_ADDRESS) loaded_image->LoadOptions,
+-                                    loaded_image->LoadOptionsSize, loaded_image->LoadOptions);
+-                if (EFI_ERROR(err)) {
+-                        Print(L"Unable to add image options measurement: %r", err);
+-                        uefi_call_wrapper(BS->Stall, 1, 3 * 1000 * 1000);
+-                        return err;
+-                }
+-#endif
 -        }
 -
          /* export the device path this image is started from */
          if (disk_get_part_uuid(loaded_image->DeviceHandle, uuid) == EFI_SUCCESS)
                  efivar_set(L"LoaderDevicePartUUID", uuid, FALSE);
--- 
-1.7.10.4
-


### PR DESCRIPTION
Systemd 2.29 added some more code to the if() body that the patch
removes.

Beware that merging this makes meta-ostro unusable unless we also merge OE-core master!
Do not merge yet unless all pieces are in place.

[skip ci]