### PR TITLE
system-and-security-architecture.rst: fix Ostro image names

### DIFF
--- a/doc/architecture/system-and-security-architecture.rst
+++ b/doc/architecture/system-and-security-architecture.rst
@@ -435,10 +435,10 @@ use them only in secure environments.
 
 
 The Ostro Project provides two different pre-compiled images,
-``ostro-os`` and ``ostro-os-dev``. Despite the name, currently *both*
+``ostro-image`` and ``ostro-image-dev``. Despite the name, currently *both*
 are compiled as development images. The only difference is that
-``ostro-os-dev`` already includes development (gcc) and debugging
-tools (strace, valgrind, etc.). There are no pre-compiled
+``ostro-image-dev`` already includes development (``gcc``) and debugging
+tools (``strace``, ``valgrind``, etc.). There are no pre-compiled
 production images.
 
 The following table summarizes the differences between the default


### PR DESCRIPTION
[skip ci]

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>