### PR TITLE
ostro.conf: update BBMASK

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -306,4 +306,4 @@ INPUTANALYZER_WHITELIST = '/(meta|meta-yocto-bsp|meta-intel|meta-java|meta-oic|m
 
 # MASK incompatible .bbappends from meta-soletta. meta-soletta's systemd
 # .bbappend is in conflict with our needs.
-BBMASK .= "|meta-soletta/recipes-configure/systemd"
+BBMASK = "meta-soletta/recipes-configure/systemd"


### PR DESCRIPTION
BBMASK setting in meta-ostro was intentionally appeding
to BBMASK since meta-oic was incorrectly initializing/
using BBMASK.

meta-oic is now fixed to not set BBMASK anymore so meta-osto's
BBMASK can be set to a sane value.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>