### PR TITLE
ostro-image.bb: creates soletta-dev packagegroup - v2

### DIFF
--- a/meta-ostro/recipes-core/packagegroups/packagegroup-soletta-dev.bb
+++ b/meta-ostro/recipes-core/packagegroups/packagegroup-soletta-dev.bb
@@ -1,0 +1,8 @@
+SUMMARY = "Development Packages for Soletta IoT Framework"
+LICENSE = "MIT"
+
+inherit packagegroup
+
+RDEPENDS_${PN} = " \
+    soletta-dev-app \
+"

--- a/meta-ostro/recipes-image/images/ostro-image.bb
+++ b/meta-ostro/recipes-image/images/ostro-image.bb
@@ -29,6 +29,7 @@ IMAGE_FEATURES[validitems] += " \
     qatests \
     smack \
     soletta \
+    soletta-dev \
     swupd \
     tools-develop \
 "
@@ -72,6 +73,7 @@ IMAGE_VARIANT[dev] = " \
     tools-debug \
     tools-develop \
     tools-profile \
+    soletta-dev \
 "
 
 # "minimal" images are the opposite of the "dev" images:
@@ -84,6 +86,7 @@ IMAGE_VARIANT[minimal] = " \
     no-node-runtime \
     no-python-runtime \
     no-soletta \
+    no-soletta-dev \
     no-qatests \
     no-java-jdk \
     ${OSTRO_EXTRA_MINIMAL_IMAGE_FEATURES} \
@@ -164,6 +167,7 @@ FEATURE_PACKAGES_node-runtime = "packagegroup-node-runtime"
 FEATURE_PACKAGES_python-runtime = "packagegroup-python-runtime"
 FEATURE_PACKAGES_java-jdk = "packagegroup-java-jdk"
 FEATURE_PACKAGES_soletta = "packagegroup-soletta"
+FEATURE_PACKAGES_soletta-dev = "packagegroup-soletta-dev"
 
 # git is not essential for compiling software, but include it anyway
 # because it is the most common source code management tool.


### PR DESCRIPTION
Cretes a packagegroup that contains the development packages for Soletta.

This packages is only needed for dev images and not production images, since
the packages should be added is only for development purposes.

Signed-off-by: Bruno Bottazzini <bruno.bottazzini@intel.com>

Differences from V1:
 - As @mythi suggested, it shouldn't be added in devkit and we should create a soletta-dev feature. 
   
Since we would add more feature in the future I created a packagegroup that we can add the dev   packages for Soletta

Previous patch:
https://github.com/ostroproject/meta-ostro/pull/25