### PR TITLE
ostro.conf: set linux-yocto preferred version to 4.1

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -58,10 +58,10 @@ DISTRO_FEATURES_DEFAULT_remove = "x11 3g"
 
 DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_LIBC} ${OSTRO_DEFAULT_DISTRO_FEATURES}"
 
-# Use 4.1 kernel for core2 and corei7.
-# BeagleBone (and others) remain unchanged on default kernel version.
-PREFERRED_VERSION_linux-yocto_intel-core2-32 ?= "4.1%"
+# Use 4.1 kernel for all MACHINEs
 PREFERRED_VERSION_linux-yocto_intel-corei7-64 ?= "4.1%"
+PREFERRED_VERSION_linux-yocto_intel-quark ?= "4.1%"
+PREFERRED_VERSION_linux-yocto_beaglebone ?= "4.1%"
 
 DISTRO_EXTRA_RDEPENDS += " ${OSTRO_DEFAULT_EXTRA_RDEPENDS}"
 DISTRO_EXTRA_RRECOMMENDS += " ${OSTRO_DEFAULT_EXTRA_RRECOMMENDS}"


### PR DESCRIPTION
oe-core/meta-intel recently moved to 4.4 on all MACHINEs we are using.

However, some of the Ostro patches that are applied via linux-yocto_%.bbappend
in meta-ostro-bsp are not (yet) compatible with 4.4. The build fails with
MACHINEs we have not properly set PREFERRED_VERSION to 4.1 for linux-yocto.

Make sure all MACHINEs set PREFERRED_VERSION to 4.1 until we are
ready to move to 4.4.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>