### PR TITLE
Add python-lxml-native to whitelisted recipes

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -140,6 +140,7 @@ PNWHITELIST_gpe-layer += ""
 PNWHITELIST_meta-initramfs += ""
 PNWHITELIST_meta-python += " \
     python-m2crypto-native \
+    python-lxml-native \
 "
 PNWHITELIST_multimedia-layer += ""
 PNWHITELIST_networking-layer += " \


### PR DESCRIPTION
This recipe is needed by isafw plugins to produce xml reports. 