### PR TITLE
Switch swupd to use bsdtar instead of GNU tar

### DIFF
--- a/meta-ostro/recipes-swupd/packagegroups/packagegroup-swupd.bb
+++ b/meta-ostro/recipes-swupd/packagegroups/packagegroup-swupd.bb
@@ -7,7 +7,6 @@ inherit packagegroup
 SUMMARY_${PN} = "Ostro OS Software updates stack"
 
 RDEPENDS_${PN} = "\
-    tar \
     swupd-client \
     clr-systemd-config \
     "

--- a/meta-ostro/recipes-swupd/swupd-client/files/0001-change-systemctl-path-to-Ostro-systemctl-path.patch
+++ b/meta-ostro/recipes-swupd/swupd-client/files/0001-change-systemctl-path-to-Ostro-systemctl-path.patch
@@ -1,8 +1,7 @@
-From 580d8a01d64a2950a929be860c0d77bb9150b865 Mon Sep 17 00:00:00 2001
+From fbded4029a9324819edaa19edf2ff1d385fbe1da Mon Sep 17 00:00:00 2001
 From: Jaska Uimonen <jaska.uimonen@intel.com>
 Date: Thu, 14 Jan 2016 10:17:43 +0200
-Subject: [PATCH swupd-client 1/5] change systemctl path to Ostro systemctl
- path
+Subject: [PATCH] change systemctl path to Ostro systemctl path
 
 Upstream-Status: Inappropriate
 

--- a/meta-ostro/recipes-swupd/swupd-client/files/0002-Fix-build-failure-on-Yocto.patch
+++ b/meta-ostro/recipes-swupd/swupd-client/files/0002-Fix-build-failure-on-Yocto.patch
@@ -1,7 +1,7 @@
-From 3c1a3571acaae24c1be6eeed66d2687001c14f2b Mon Sep 17 00:00:00 2001
+From 27310e687f248a04456d1e68d8a0adc2711bb380 Mon Sep 17 00:00:00 2001
 From: Amarnath Valluri <amarnath.valluri@intel.com>
 Date: Thu, 7 Jan 2016 16:19:34 +0200
-Subject: [PATCH swupd-client 2/5] Fix build failure on Yocto
+Subject: [PATCH] Fix build failure on Yocto
 
 On install phase certificate files are being installed twice as included in
 _DATA twice. We can use EXTRA_DIST than dist_.

--- a/meta-ostro/recipes-swupd/swupd-client/files/0003-Right-usage-of-AC_ARG_ENABLE-on-bzip2.patch
+++ b/meta-ostro/recipes-swupd/swupd-client/files/0003-Right-usage-of-AC_ARG_ENABLE-on-bzip2.patch
@@ -1,7 +1,7 @@
-From ac1478df483a15d8098e53add04fa6e990699be1 Mon Sep 17 00:00:00 2001
+From 4472212c12db7be14ce9df292776379391f76c8c Mon Sep 17 00:00:00 2001
 From: Amarnath Valluri <amarnath.valluri@intel.com>
 Date: Wed, 13 Jan 2016 15:46:19 +0200
-Subject: [PATCH swupd-client 3/5] Right usage of AC_ARG_ENABLE on bzip2
+Subject: [PATCH] Right usage of AC_ARG_ENABLE on bzip2
 
 Upstream-Status: Pending[Not submitted]
 

--- a/meta-ostro/recipes-swupd/swupd-client/files/0004-Tolerate-quotes-in-os-release-files.patch
+++ b/meta-ostro/recipes-swupd/swupd-client/files/0004-Tolerate-quotes-in-os-release-files.patch
@@ -1,7 +1,7 @@
-From d37f7df9432790b4e89d7616d8a8369af1b7435e Mon Sep 17 00:00:00 2001
+From 0ac7226645db1c7048863755a296e1e5f7d8319c Mon Sep 17 00:00:00 2001
 From: Dmitry Rozhkov <dmitry.rozhkov@intel.com>
 Date: Thu, 11 Feb 2016 12:49:30 +0200
-Subject: [PATCH swupd-client 4/5] Tolerate quotes in os-release files
+Subject: [PATCH] Tolerate quotes in os-release files
 
 Some systems like Yocto or OpenSUSE prefer to wrap values in
 /etc/os-release file with quotes always and that still conforms

--- a/meta-ostro/recipes-swupd/swupd-client/files/0005-Disable-boot-file-heuristics.patch
+++ b/meta-ostro/recipes-swupd/swupd-client/files/0005-Disable-boot-file-heuristics.patch
@@ -1,7 +1,7 @@
-From 69b382558db9330b4c442b05003c47afca0c33ad Mon Sep 17 00:00:00 2001
+From 5f93d2ff31607539ce9957daf78f920e25873b4a Mon Sep 17 00:00:00 2001
 From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
 Date: Tue, 23 Feb 2016 17:07:30 +0200
-Subject: [PATCH swupd-client 5/5] Disable boot file heuristics
+Subject: [PATCH] Disable boot file heuristics
 
 Ostro uses a mechanism different from what's used in ClearLinux
 to detect changes in kernel, bootloader, initramfs.

--- a/meta-ostro/recipes-swupd/swupd-client/files/0006-swupd-client-Add-existence-check-to-staging-target.patch
+++ b/meta-ostro/recipes-swupd/swupd-client/files/0006-swupd-client-Add-existence-check-to-staging-target.patch
@@ -1,0 +1,96 @@
+From 1f37511e52754f7231c52489ba4f7d8f7de1e2af Mon Sep 17 00:00:00 2001
+From: "Brad T. Peters" <brad.t.peters@intel.com>
+Date: Thu, 7 Jan 2016 14:37:17 -0800
+Subject: [PATCH] swupd-client: Add existence check to staging target
+
+Patch adds an stat() check to ensure that:
+1. target path for a staged file exists, and
+2. target path is indeed a directory
+
+Follow-on patch will add correct corrective behavior once
+verify_fix_path() is implemented
+
+Upstream-Status: Accepted
+
+Signed-off-by: Brad T. Peters <brad.t.peters@intel.com>
+---
+ src/staging.c | 39 ++++++++++++++++++++++++++++++++-------
+ 1 file changed, 32 insertions(+), 7 deletions(-)
+
+diff --git a/src/staging.c b/src/staging.c
+index 3a847e2..b8545c1 100644
+--- a/src/staging.c
++++ b/src/staging.c
+@@ -277,9 +277,11 @@ int do_staging(struct file *file)
+ #if SWUPD_LINUX_ROOTFS
+ 	char *original = NULL;
+ 	char *target = NULL;
++	char *targetpath = NULL;
++	char *symbase = NULL;
+ #endif
+ 	int ret;
+-	struct stat stat;
++	struct stat s;
+ 
+ 	tmp = strdup(file->filename);
+ 	tmp2 = strdup(file->filename);
+@@ -294,6 +296,29 @@ int do_staging(struct file *file)
+ 	string_or_die(&original, "%s/staged/%s", STATE_DIR, file->hash);
+ 
+ #if SWUPD_LINUX_ROOTFS
++	string_or_die(&targetpath, "%s%s", path_prefix, rel_dir);
++	ret = stat(targetpath, &s);
++
++	if (S_ISLNK(s.st_mode)) {
++		/* Follow symlink to ultimate target and redo stat */
++		symbase = realpath(targetpath, NULL);
++		if (symbase != NULL) {
++			free(targetpath);
++			targetpath = strdup(symbase);
++			ret = stat(targetpath, &s);
++			free(symbase);
++		}
++	}
++
++	/* For now, just report on error conditions. Once we implement
++	* verify_fix_path(char *path, int targetversion), we'll want to call it here */
++	if ((ret == -1) && (errno == ENOENT)) {
++		printf("Error: Update target directory does not exist: %s\n", targetpath);
++	} else if (!S_ISDIR(s.st_mode)) {
++		printf("Error: Update target exists but is NOT a directory: %s\n", targetpath);
++	}
++
++	free(targetpath);
+ 	string_or_die(&target, "%s%s/.update.%s", path_prefix, rel_dir, base);
+ 	ret = swupd_rm(target);
+ 	if (ret == 0)
+@@ -306,12 +331,12 @@ int do_staging(struct file *file)
+ 	string_or_die(&statfile, "%s/%s/%s", STAGING_SUBVOL, rel_dir, base);
+ #endif
+ 
+-	memset(&stat, 0, sizeof(struct stat));
+-	ret = lstat(statfile, &stat);
++	memset(&s, 0, sizeof(struct stat));
++	ret = lstat(statfile, &s);
+ 	if (ret == 0) {
+-		if ((file->is_dir  && !S_ISDIR(stat.st_mode)) ||
+-		    (file->is_link && !S_ISLNK(stat.st_mode)) ||
+-		    (file->is_file && !S_ISREG(stat.st_mode))) {
++		if ((file->is_dir  && !S_ISDIR(s.st_mode)) ||
++		    (file->is_link && !S_ISLNK(s.st_mode)) ||
++		    (file->is_file && !S_ISREG(s.st_mode))) {
+ 			LOG_INFO(file, "Type changed!", class_osvol_staging, "%s", statfile);
+ 			//file type changed, move old out of the way for new
+ 			ret = swupd_rm(statfile);
+@@ -325,7 +350,7 @@ int do_staging(struct file *file)
+ 	free(statfile);
+ 
+ #if SWUPD_LINUX_ROOTFS
+-	if (file->is_dir || S_ISDIR(stat.st_mode)) {
++	if (file->is_dir || S_ISDIR(s.st_mode)) {
+ 		/* In the btrfs only scenario there is an implicit
+ 		 * "create_or_update_dir()" via un-tar-ing a directory.tar after
+ 		 * download and the untar happens in the staging subvolume which
+-- 
+2.5.0
+

--- a/meta-ostro/recipes-swupd/swupd-client/files/0007-Backport-Use-rename-instead-of-tar-transform.patch
+++ b/meta-ostro/recipes-swupd/swupd-client/files/0007-Backport-Use-rename-instead-of-tar-transform.patch
@@ -1,0 +1,157 @@
+From e9ad32a273efe2d177c1bbd394ae944ae598fd50 Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@intel.com>
+Date: Mon, 8 Feb 2016 18:12:48 +0200
+Subject: [PATCH] Backport: Use rename instead of tar transform
+
+This patch is a backport from swupd-client v2.88
+Author: William Douglas <william.douglas@intel.com>
+Subject: Use rename instead of tar transform
+
+In order to prevent issues with transform name escaping, update logic
+for moving an object from staging. First rename the object in the
+staging path to its final name (in case of a directory the rename places
+it in a seperate directory first to avoid hash colisions), then use tar
+to update or create the object in the filesystem. Once finished rename
+the object back to the hash name so it can be reused as needed.
+
+This also fixes up some issues with the SWUPD_LINUX_ROOTFS checks not
+always encapsulating variable use within the do_staging function.
+
+Note: the SWUPD_LINUX_ROOTFS checks have been removed entirely, since
+they are not used anywhere in the code at present.
+
+Upstream-Status: Backported
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ src/staging.c | 73 ++++++++++++++++++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 67 insertions(+), 6 deletions(-)
+
+diff --git a/src/staging.c b/src/staging.c
+index b8545c1..16dafbb 100644
+--- a/src/staging.c
++++ b/src/staging.c
+@@ -36,6 +36,31 @@
+ #include "swupd-build-variant.h"
+ #include <swupd.h>
+ 
++/* clean then recreate temporary folder for tar renames */
++static int create_staging_renamedir(char *rename_tmpdir)
++{
++	int ret;
++	char *rmcommand = NULL;
++
++	string_or_die(&rmcommand, "rm -fr %s", rename_tmpdir);
++	if (!system(rmcommand)) {
++		/* Not fatal but pretty scary, likely to really fail at the
++		 * next command too. Pass for now as printing may just cause
++		 * confusion */
++		;
++	}
++	free(rmcommand);
++
++	ret = mkdir(rename_tmpdir, S_IRWXU);
++	if (ret == -1 && errno != EEXIST) {
++		ret = -errno;
++	} else {
++		ret = 0;
++	}
++
++	return ret;
++}
++
+ #ifdef SWUPD_WITH_BTRFS
+ static int create_staging_subvol_from(const char *version)
+ {
+@@ -269,6 +294,9 @@ int prepare(bool UNUSED_PARAM *is_corrupted, int UNUSED_PARAM current_version, i
+ #endif
+ 
+ /* Do the staging of new files into the filesystem */
++#warning do_staging is currently not able to be run in parallel
++/* Consider adding a remove_leftovers() that runs in verify/fix in order to
++ * allow this function to mkdtemp create folders for parallel build */
+ int do_staging(struct file *file)
+ {
+ 	char *statfile = NULL, *tmp = NULL, *tmp2 = NULL;
+@@ -280,6 +308,8 @@ int do_staging(struct file *file)
+ 	char *targetpath = NULL;
+ 	char *symbase = NULL;
+ #endif
++	char *rename_target = NULL;
++	char *rename_tmpdir = NULL;
+ 	int ret;
+ 	struct stat s;
+ 
+@@ -360,12 +390,28 @@ int do_staging(struct file *file)
+ 		 * attributes and it includes internal logic that does the
+ 		 * right thing to overlay a directory onto something
+ 		 * pre-existing: */
+-		string_or_die(&tarcommand, "tar -C %s/staged " TAR_PERM_ATTR_ARGS " -cf - %s 2> /dev/null | "
+-			"tar -C %s%s " TAR_PERM_ATTR_ARGS " -xf - --transform=\"s/%s/%s/\" 2> /dev/null",
+-			STATE_DIR, file->hash, path_prefix, rel_dir, file->hash, base);
++		/* In order to avoid tar transforms with directories, rename
++		 * the directory before and after the tar command */
++		string_or_die(&rename_tmpdir, "%s/tmprenamedir", STATE_DIR);
++		ret = create_staging_renamedir(rename_tmpdir);
++		if (ret) {
++			goto out;
++		}
++		string_or_die(&rename_target, "%s/%s", rename_tmpdir, base);
++		if (rename(original, rename_target)) {
++			ret = -errno;
++			goto out;
++		}
++		string_or_die(&tarcommand, "tar -C %s " TAR_PERM_ATTR_ARGS " -cf - %s 2> /dev/null | "
++			"tar -C %s%s " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
++			rename_tmpdir, base, path_prefix, rel_dir);
+ 		LOG_DEBUG(file, "directory overwrite", class_osvol_staging, "%s", tarcommand);
+ 		ret = system(tarcommand);
+ 		free(tarcommand);
++		if (rename(rename_target, original)) {
++			ret = -errno;
++			goto out;
++		}
+ 		if (ret < 0) {
+ 			LOG_ERROR(file, "Failed directory overwrite", class_osvol_staging, "%s", strerror(errno));
+ 			ret = -EDIR_OVERWRITE;
+@@ -386,12 +432,25 @@ int do_staging(struct file *file)
+ 		}
+ 		if (ret < 0) {
+ 			/* either the hardlink failed, or it was undesirable (config), do a tar-tar dance */
+-			string_or_die(&tarcommand, "tar -C %s/staged " TAR_PERM_ATTR_ARGS " -cf - %s 2> /dev/null | "
+-				"tar -C %s%s " TAR_PERM_ATTR_ARGS " -xf - --transform=\"s/%s/.update.%s/\" 2> /dev/null",
+-				STATE_DIR, file->hash, path_prefix, rel_dir, file->hash, base);
++			/* In order to avoid tar transforms, rename the file
++			 * before and after the tar command */
++			string_or_die(&rename_target, "%s/staged/.update.%s", STATE_DIR, base);
++			ret = rename(original, rename_target);
++			if (ret) {
++				ret = -errno;
++				goto out;
++			}
++			string_or_die(&tarcommand, "tar -C %s/staged " TAR_PERM_ATTR_ARGS " -cf - .update.%s 2> /dev/null | "
++				"tar -C %s%s " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
++				STATE_DIR, base, path_prefix, rel_dir);
+ 			LOG_DEBUG(file, "dotfile install", class_osvol_staging, "%s", tarcommand);
+ 			ret = system(tarcommand);
+ 			free(tarcommand);
++			ret = rename(rename_target, original);
++			if (ret) {
++				ret = -errno;
++				goto out;
++			}
+ 		}
+ 		if (ret < 0) {
+ 			LOG_ERROR(file, "Failed tar dotfile install", class_osvol_staging,
+@@ -436,6 +495,8 @@ int do_staging(struct file *file)
+ out:
+ 	free(target);
+ 	free(original);
++	free(rename_target);
++	free(rename_tmpdir);
+ 	free(tmp);
+ 	free(tmp2);
+ 
+-- 
+2.5.0
+

--- a/meta-ostro/recipes-swupd/swupd-client/files/0008-Add-compatibility-with-libarchive-s-bsdtar-command.patch
+++ b/meta-ostro/recipes-swupd/swupd-client/files/0008-Add-compatibility-with-libarchive-s-bsdtar-command.patch
@@ -1,0 +1,183 @@
+From 29e2fefaf67bfd6db77db87d22782a31c7284982 Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@intel.com>
+Date: Mon, 8 Feb 2016 16:42:23 +0200
+Subject: [PATCH] Add compatibility with libarchive's bsdtar command
+
+Since GNU tar fails to extract files with xattrs preserved when
+Integrity Measurement Architecture (IMA) is enabled some vendors
+may choose to install libarchive-based tar (bsdtar) on their embedded
+devices, so the swupd server needs to be able to create archives
+in its format.
+
+This patch adds one compile-time options --enable-bsdtar that is used
+to enable/disable GNU tar specific options.
+
+Upstream-Status: Submitted [https://github.com/clearlinux/swupd-client/pull/13]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ configure.ac                  |  9 +++++++++
+ include/swupd-build-variant.h | 12 ++++++++++--
+ src/download.c                |  4 ++--
+ src/esp.c                     |  4 ++--
+ src/manifest.c                |  3 ++-
+ src/packs.c                   |  2 +-
+ src/staging.c                 | 12 ++++++------
+ 7 files changed, 32 insertions(+), 14 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index b11ef0a..930f64c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -29,6 +29,15 @@ AS_IF([test "x$enable_bzip2" = "xyes" ],
+   [AC_DEFINE(SWUPD_WITHOUT_BZIP2,1,[Do not use bzip2 compression])]
+ )
+ 
++AC_ARG_ENABLE(
++	[bsdtar],
++	AS_HELP_STRING([--enable-bsdtar], [Use alternative bsdtar command (uses tar by default)])
++)
++AS_IF([test "x$enable_bsdtar" = "xyes" ],
++	[AC_DEFINE(SWUPD_WITH_BSDTAR, 1, [Use bsdtar])],
++    [AC_DEFINE(SWUPD_WITHOUT_BSDTAR, 1, [Use default tar])]
++)
++
+ AC_ARG_WITH([systemdsystemunitdir], AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
+             [path to systemd system service dir @<:@default=/usr/lib/systemd/system@:>@]), [unitpath=${withval}],
+             [unitpath="$($PKG_CONFIG --variable=systemdsystemunitdir systemd)"])
+diff --git a/include/swupd-build-variant.h b/include/swupd-build-variant.h
+index f2103a2..0c15dca 100644
+--- a/include/swupd-build-variant.h
++++ b/include/swupd-build-variant.h
+@@ -13,10 +13,18 @@
+ #define VERIFY_FAILED_MAX_VERSIONS_COUNT 20
+ #endif
+ 
++#ifdef SWUPD_WITH_BSDTAR
++#define TAR_COMMAND "bsdtar"
++#define TAR_XATTR_ARGS ""
++#else
++#define TAR_COMMAND "tar"
++#define TAR_XATTR_ARGS "--xattrs --xattrs-include='*'"
++#endif
++
+ #ifdef SWUPD_WITH_SELINUX
+-#define TAR_PERM_ATTR_ARGS "--preserve-permissions --xattrs --xattrs-include='*' --selinux"
++#define TAR_PERM_ATTR_ARGS "--preserve-permissions --selinux " TAR_XATTR_ARGS
+ #else /* SWUPD_WITHOUT_SELINUX */
+-#define TAR_PERM_ATTR_ARGS "--preserve-permissions --xattrs --xattrs-include='*'"
++#define TAR_PERM_ATTR_ARGS "--preserve-permissions " TAR_XATTR_ARGS
+ #endif
+ 
+ #ifdef SWUPD_WITH_REPAIR
+diff --git a/src/download.c b/src/download.c
+index cb6d1a2..211ee24 100644
+--- a/src/download.c
++++ b/src/download.c
+@@ -194,7 +194,7 @@ static int check_tarfile_content(struct file *file, const char *tarfilename)
+ 	int count = 0;
+ 
+ 	/* we're using -a because the server side has a choice between different compression methods */
+-	string_or_die(&tarcommand, "tar -tf %s/download/%s.tar 2> /dev/null", STATE_DIR, file->hash);
++	string_or_die(&tarcommand, TAR_COMMAND " -tf %s/download/%s.tar 2> /dev/null", STATE_DIR, file->hash);
+ 
+ 	err = access(tarfilename, R_OK);
+ 	if (err) {
+@@ -300,7 +300,7 @@ static void untar_full_download(void *data)
+ 	}
+ 
+ 	/* modern tar will automatically determine the compression type used */
+-	string_or_die(&tarcommand, "tar -C %s/staged/ " TAR_PERM_ATTR_ARGS " -xf %s 2> /dev/null",
++	string_or_die(&tarcommand, TAR_COMMAND " -C %s/staged/ " TAR_PERM_ATTR_ARGS " -xf %s 2> /dev/null",
+ 			STATE_DIR, tarfile);
+ 
+ 	LOG_DEBUG(file, "Doing tar operation", class_file_compression, "%s", tarcommand);
+diff --git a/src/esp.c b/src/esp.c
+index e2b2ae9..3483f55 100644
+--- a/src/esp.c
++++ b/src/esp.c
+@@ -231,8 +231,8 @@ int copy_files_to_esp(int target_version)
+ 
+ 	progress_step(PROGRESS_MSG_UPDATE_ESP);
+ 
+-	string_or_die(&tarcommand, "tar -C %s/%d/system/vendor/intel/ -cf - esp 2> /dev/null | "
+-				  "tar -C %s/ -xf - --no-same-permissions --no-same-owner --transform=\"s/esp//\" 2> /dev/null",
++	string_or_die(&tarcommand, TAR_COMMAND " -C %s/%d/system/vendor/intel/ -cf - esp 2> /dev/null | "
++				  TAR_COMMAND " -C %s/ -xf - --no-same-permissions --no-same-owner --transform=\"s/esp//\" 2> /dev/null",
+ 				  MOUNT_POINT, target_version, ESP_MOUNT);
+ 
+ 	ret = system(tarcommand);
+diff --git a/src/manifest.c b/src/manifest.c
+index 5757e9f..7c356d7 100644
+--- a/src/manifest.c
++++ b/src/manifest.c
+@@ -34,6 +34,7 @@
+ #include <fcntl.h>
+ 
+ #include "config.h"
++#include "swupd-build-variant.h"
+ #include <swupd.h>
+ #include <xattrs.h>
+ #include "progress.h"
+@@ -519,7 +520,7 @@ static int retrieve_manifests(int current, int version, char *component, struct
+ 		goto out;
+ 	}
+ 
+-	string_or_die(&tar, "tar -C %s/%i -xf %s/%i/Manifest.%s.tar 2> /dev/null",
++	string_or_die(&tar, TAR_COMMAND " -C %s/%i -xf %s/%i/Manifest.%s.tar 2> /dev/null",
+ 			STATE_DIR, version, STATE_DIR, version, component);
+ 
+ 	LOG_DEBUG(NULL, "tar", class_file_compression, "running %s", tar);
+diff --git a/src/packs.c b/src/packs.c
+index b176b74..91a83c5 100644
+--- a/src/packs.c
++++ b/src/packs.c
+@@ -83,7 +83,7 @@ static int download_pack(int oldversion, int newversion, char *module)
+ 	free(url);
+ 
+ 	progress_step(PROGRESS_MSG_EXTRACTING_PACK);
+-	string_or_die(&tar, "tar -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar 2> /dev/null",
++	string_or_die(&tar, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar 2> /dev/null",
+ 			STATE_DIR, STATE_DIR, module, oldversion, newversion);
+ 
+ 	LOG_INFO(NULL, "Untar of delta pack", class_file_compression, "%s", tar);
+diff --git a/src/staging.c b/src/staging.c
+index 16dafbb..742e8a2 100644
+--- a/src/staging.c
++++ b/src/staging.c
+@@ -402,8 +402,8 @@ int do_staging(struct file *file)
+ 			ret = -errno;
+ 			goto out;
+ 		}
+-		string_or_die(&tarcommand, "tar -C %s " TAR_PERM_ATTR_ARGS " -cf - %s 2> /dev/null | "
+-			"tar -C %s%s " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
++		string_or_die(&tarcommand, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -cf - %s 2> /dev/null | "
++			TAR_COMMAND " -C %s%s " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
+ 			rename_tmpdir, base, path_prefix, rel_dir);
+ 		LOG_DEBUG(file, "directory overwrite", class_osvol_staging, "%s", tarcommand);
+ 		ret = system(tarcommand);
+@@ -440,8 +440,8 @@ int do_staging(struct file *file)
+ 				ret = -errno;
+ 				goto out;
+ 			}
+-			string_or_die(&tarcommand, "tar -C %s/staged " TAR_PERM_ATTR_ARGS " -cf - .update.%s 2> /dev/null | "
+-				"tar -C %s%s " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
++			string_or_die(&tarcommand, TAR_COMMAND " -C %s/staged " TAR_PERM_ATTR_ARGS " -cf - .update.%s 2> /dev/null | "
++				TAR_COMMAND " -C %s%s " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
+ 				STATE_DIR, base, path_prefix, rel_dir);
+ 			LOG_DEBUG(file, "dotfile install", class_osvol_staging, "%s", tarcommand);
+ 			ret = system(tarcommand);
+@@ -485,8 +485,8 @@ int do_staging(struct file *file)
+ 	/* For initial simplicity replace the file.  Ideally this would be
+ 	 * an intelligent btrfs reflink to maximize block level reuse. */
+ 	//TODO: prove btrfs reflink ioctl works in general, then try using them here
+-	string_or_die(&tarcommand, "tar -C %s/staged " TAR_PERM_ATTR_ARGS " -cf - %s 2> /dev/null | "
+-		"tar -C %s/%s " TAR_PERM_ATTR_ARGS " -xf - --transform=\"s/%s/%s/\" 2> /dev/null",
++	string_or_die(&tarcommand, TAR_COMMAND " -C %s/staged " TAR_PERM_ATTR_ARGS " -cf - %s 2> /dev/null | "
++		TAR_COMMAND " -C %s/%s " TAR_PERM_ATTR_ARGS " -xf - --transform=\"s/%s/%s/\" 2> /dev/null",
+ 		STATE_DIR, file->hash, STAGING_SUBVOL, rel_dir, file->hash, base);
+ 	ret = system(tarcommand);
+ 	free(tarcommand);
+-- 
+2.5.0
+

--- a/meta-ostro/recipes-swupd/swupd-client/swupd-client_5700.bb
+++ b/meta-ostro/recipes-swupd/swupd-client/swupd-client_5700.bb
@@ -11,6 +11,9 @@ SRC_URI = " \
   file://0003-Right-usage-of-AC_ARG_ENABLE-on-bzip2.patch \
   file://0004-Tolerate-quotes-in-os-release-files.patch \
   file://0005-Disable-boot-file-heuristics.patch \
+  file://0006-swupd-client-Add-existence-check-to-staging-target.patch \
+  file://0007-Backport-Use-rename-instead-of-tar-transform.patch \
+  file://0008-Add-compatibility-with-libarchive-s-bsdtar-command.patch \
   file://efi_combo_updater.c \
   "
 SRC_URI[md5sum] = "58671adf559dd18620f11caf4ccf83dd"
@@ -19,14 +22,14 @@ SRC_URI[sha256sum] = "09a70a423d10a6bf71f8675b7430c29a56f41f93493331c9ae51501171
 inherit pkgconfig
 
 DEPENDS = "zlib curl openssl xz glib-2.0"
-RDEPENDS_${PN} = "xz tar gptfdisk glib-2.0 bash"
+RDEPENDS_${PN} = "xz bsdtar gptfdisk glib-2.0 bash"
 
 PACKAGECONFIG ??= "bzip2"
 PACKAGECONFIG[bzip2] = "--enable-bzip2,--disable-bzip2,bzip2"
 
 inherit pkgconfig autotools
 
-EXTRA_OECONF = "--with-systemdsystemunitdir=${base_libdir}/systemd/system"
+EXTRA_OECONF = "--with-systemdsystemunitdir=${base_libdir}/systemd/system --enable-bsdtar"
 
 FILES_${PN} += " \
   ${datadir}/clear/update-ca/ \


### PR DESCRIPTION
Currently GNU tar can't be used when IMA is enabled because
upon extracting a file it first creates it with `mknodat()`,
sets its xattrs and only then tries to open for writing and
fails since IMA prevents it.

This patch adds patches to swupd making it compatible with
bsdtar and switches it to actually use bsdtar.

Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>