### PR TITLE
image-dsk.class: modify rootfs partition size to fit on 4GB media

### DIFF
--- a/meta-ostro/classes/image-dsk.bbclass
+++ b/meta-ostro/classes/image-dsk.bbclass
@@ -85,7 +85,7 @@ DSK_IMAGE_LAYOUT ??= ' \
     "partition_03_rootfs": { \
         "name": "rootfs", \
         "uuid": "${ROOTFS_PARTUUID_VALUE}", \
-        "size_mb": 5000, \
+        "size_mb": 3700, \
         "source": "${IMAGE_ROOTFS}", \
         "filesystem": "ext4", \
         "type": "8300" \


### PR DESCRIPTION
It is not uncommon in the IoT space to use 4GB media to host your
OS. 4GB usually means 4.000.000.000 bytes and hence translates
into a real useable size of 3814MB. Setting the size of the rootfs
partition to 3700MB gives us a little buffer and should work with
all 4GB storage media (USB, SD cards, etc.) out there.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>