### PR TITLE
ostro-imabe.bb: creates FEATURE_PACKAGES soletta-tools V4

### DIFF
--- a/meta-ostro/recipes-image/images/ostro-image.bb
+++ b/meta-ostro/recipes-image/images/ostro-image.bb
@@ -29,6 +29,7 @@ IMAGE_FEATURES[validitems] += " \
     qatests \
     smack \
     soletta \
+    soletta-tools \
     swupd \
     tools-develop \
 "
@@ -72,6 +73,7 @@ IMAGE_VARIANT[dev] = " \
     tools-debug \
     tools-develop \
     tools-profile \
+    soletta-tools \
 "
 
 # "minimal" images are the opposite of the "dev" images:
@@ -84,6 +86,7 @@ IMAGE_VARIANT[minimal] = " \
     no-node-runtime \
     no-python-runtime \
     no-soletta \
+    no-soletta-tools \
     no-qatests \
     no-java-jdk \
     ${OSTRO_EXTRA_MINIMAL_IMAGE_FEATURES} \
@@ -164,6 +167,7 @@ FEATURE_PACKAGES_node-runtime = "packagegroup-node-runtime"
 FEATURE_PACKAGES_python-runtime = "packagegroup-python-runtime"
 FEATURE_PACKAGES_java-jdk = "packagegroup-java-jdk"
 FEATURE_PACKAGES_soletta = "packagegroup-soletta"
+FEATURE_PACKAGES_soletta-tools = "soletta-dev-app"
 
 # git is not essential for compiling software, but include it anyway
 # because it is the most common source code management tool.


### PR DESCRIPTION
Cretes a FEATURE_PACKAGES that contains development tool for Soletta.

So far, It includes just the Soletta Dev-App tool.

The feature is for only development purposes. It needs to be included only
in dev images.

Signed-off-by: Bruno Bottazzini <bruno.bottazzini@intel.com>

Differences from V3:
As @mythi and @barbieri suggested. Remove the packagegroup, and in the future, when adding more tools, we can create one or decide to put them somewhere else.

Differences from V2:
As pointed by @kad and @mythi, we had a name conflict and the build was failing. 
Changed the name to be soletta-dev-tools instead of soletta-dev.

Differences from V1:

As @mythi suggested, it shouldn't be added in devkit and we should create a soletta-dev feature.
Since we would add more feature in the future I created a packagegroup that we can add the dev packages for Soletta

Previous patch:
#35 