### PR TITLE
swupd: remove dependency on tar from packagegroup-swupd

### DIFF
--- a/meta-ostro/recipes-swupd/packagegroups/packagegroup-swupd.bb
+++ b/meta-ostro/recipes-swupd/packagegroups/packagegroup-swupd.bb
@@ -7,7 +7,6 @@ inherit packagegroup
 SUMMARY_${PN} = "Ostro OS Software updates stack"
 
 RDEPENDS_${PN} = "\
-    tar \
     swupd-client \
     clr-systemd-config \
     "


### PR DESCRIPTION
swupd-client depends on tar already and setting one more
dependency on tar is redundant and doesn't add value
to the packagegroup.

Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>