### PR TITLE
Revert "ostro_security_flags.inc: Disable -fstack-protector-strong for openjdk"

### DIFF
--- a/meta-ostro/conf/distro/include/ostro_security_flags.inc
+++ b/meta-ostro/conf/distro/include/ostro_security_flags.inc
@@ -8,16 +8,3 @@ SECURITY_CFLAGS_pn-upm = "${SECURITY_NO_PIE_CFLAGS}"
 SECURITY_CFLAGS_pn-iot-app-fw = "${SECURITY_NO_PIE_CFLAGS}"
 SECURITY_CFLAGS_pn-iotivity = "${SECURITY_NO_PIE_CFLAGS}"
 SECURITY_CFLAGS_pn-krb5 = "${SECURITY_NO_PIE_CFLAGS}"
-
-
-
-
-# Workaround for issue, where a) openjdk uses system gcc, and b)
-# system gcc is 4.8 or older and -fstack-protector-strong is not supported
-
-SECURITY_LDFLAGS_remove_pn-openjdk-8-jre = "-fstack-protector-strong"
-SECURITY_LDFLAGS_append_pn-openjdk-8-jre = " -fstack-protector-all"
-
-
-SECURITY_CFLAGS_remove_pn-openjdk-8-jre = "-fstack-protector-strong"
-SECURITY_CFLAGS_append_pn-openjdk-8-jre = " -fstack-protector-all"


### PR DESCRIPTION
This reverts commit 9324c2f725ebd382e094ffec26a2a05a2e50615b.

The commit was a temporary fix for a scenario, where builds on certain
compilers were failing. The proper fix for this has been merged, so
this can be reverted.

Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>