### PR TITLE
support xz and zip compressed images

### DIFF
--- a/doc/howtos/building-images.rst
+++ b/doc/howtos/building-images.rst
@@ -123,6 +123,13 @@ compressed formats:
     temporary space, because the creation of the compressed image depends
     on the presence of the uncompressed one.
 
+    All compression methods listed for ``COMPRESSIONTYPES`` in
+    ``meta/classes/image_types.bbclass`` are supported. In addition,
+    Ostro OS adds support for compressing with :command:`zip`. ``xz``
+    is recommended, while ``zip`` may be useful in cases where images
+    have to be decompressed on machines that do not have :command:`xz`
+    readily available.
+
 To customize the image format, modify ``local.conf``, adding the variable
 ``OSTRO_VM_IMAGE_TYPES``, set to any combination of the following::
 

--- a/doc/howtos/building-images.rst
+++ b/doc/howtos/building-images.rst
@@ -103,6 +103,41 @@ no IMA keys are needed::
     OSTRO_EXTRA_IMAGE_VARIANTS = "imagevariant:noima imagevariant:dev,noima"
 
 
+Image Formats for EFI platforms
+-------------------------------
+
+Note: The following chapter is applicable only to EFI platforms.
+
+It is possible to produce different types of images:
+
+.dsk:
+    The basic format, which can be written to a block device with "dd".
+
+.dsk.vdi:
+    VirtualBox format, for running OSTRO inside a Virtual Machine.
+
+compressed formats:
+    Same as above, only compressed, to reduce (final) space occupation
+    and speed up the transfer between systems of the Ostro OS image.
+    Notice that the creation of compressed images will require additional
+    temporary space, because the creation of the compressed image depends
+    on the presence of the uncompressed one.
+
+To customize the image format, modify ``local.conf``, adding the variable
+``OSTRO_VM_IMAGE_TYPES``, set to any combination of the following::
+
+    dsk dsk.xz dsk.vdi dsk.vdi.xz
+
+It will also trigger the creation of corresponding symlinks.
+
+Example::
+
+    OSTRO_VM_IMAGE_TYPES = "dsk.xz dsk.vdi.xz"
+
+will create both the raw and the VirtualBox images, both compressed.
+
+
+
 Development Images
 ------------------
 

--- a/meta-ostro/lib/image-dsk.py
+++ b/meta-ostro/lib/image-dsk.py
@@ -98,7 +98,6 @@ def do_dsk_image():
     check_call(['truncate',  '-s', str(full_image_size_mb) + 'M',
                full_image_name])
     check_call(['sgdisk', '-o', full_image_name])
-    symlink(expand_vars('${IMAGE_NAME}.dsk'), full_image_name_link)
 
     partition_start_mb = partition_table["gpt_initial_offset_mb"]
     for key in sorted(partition_table.iterkeys()):
@@ -139,34 +138,6 @@ def do_dsk_image():
         if os.path.exists(full_partition_name):
             os.remove(full_partition_name)
         partition_start_mb += partition_table[key]["size_mb"]
-
-    image_types = lookup_var("IMAGE_FSTYPES").split()
-    # Build .vdi images for use with VirtualBox, if so requested.
-    if "dsk.vdi" in image_types:
-        vdi_image_name = \
-            os.path.join(expand_vars("${DEPLOY_DIR_IMAGE}"),
-                         expand_vars('${IMAGE_NAME}.dsk.vdi'))
-        vdi_image_name_link = \
-            os.path.join(expand_vars("${DEPLOY_DIR_IMAGE}"),
-                         expand_vars('${BPN}-${MACHINE}.dsk.vdi'))
-        check_call(['qemu-img', 'convert', '-O', 'vdi',
-                                full_image_name, vdi_image_name])
-        symlink(expand_vars('${IMAGE_NAME}.dsk.vdi'), vdi_image_name_link)
-    # If requested, create a xz compressed version of the dsk image.
-    if "dsk_xz" in image_types:
-        xz_image_name = \
-            os.path.join(expand_vars("${DEPLOY_DIR_IMAGE}"),
-                         expand_vars('${IMAGE_NAME}.dsk.xz'))
-        xz_image_name_link = \
-            os.path.join(expand_vars("${DEPLOY_DIR_IMAGE}"),
-                         expand_vars('${BPN}-${MACHINE}.dsk.xz'))
-        check_call(['xz', '-3', '-vk', full_image_name])
-        symlink(expand_vars('${IMAGE_NAME}.dsk.xz'), xz_image_name_link)
-    # If the plain .dsk file was not requested, remove it and save space.
-    if not "dsk" in image_types:
-        os.remove(full_image_name)
-        os.remove(full_image_name_link)
-
 
 if __name__ == "__main__":
     do_dsk_image()

--- a/meta-ostro/recipes-image/images/ostro-image.bb
+++ b/meta-ostro/recipes-image/images/ostro-image.bb
@@ -190,6 +190,13 @@ ostro_root_authorized_keys () {
 # Do not create ISO images by default, only HDDIMG will be created (if it gets created at all).
 NOISO = "1"
 
+# Add support for compressing images with zip. Works for arbitrary image
+# types. Example: OSTRO_VM_IMAGE_TYPES = "dsk.zip dsk.vdi.zip"
+COMPRESSIONTYPES_append = " zip"
+ZIP_COMPRESSION_LEVEL ?= "-9"
+COMPRESS_CMD_zip = "zip ${ZIP_COMPRESSION_LEVEL} ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}.zip ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}"
+COMPRESS_DEPENDS_zip = "zip-native"
+
 # Replace the default "live" (aka HDDIMG) images with whole-disk images
 # XXX Drop the VM hack after taking care also of the non UEFI devices (those using U-Boot: edison and beaglebone)
 OSTRO_VM_IMAGE_TYPES ?= "dsk dsk.xz dsk.vdi"

--- a/meta-ostro/recipes-image/images/ostro-image.bb
+++ b/meta-ostro/recipes-image/images/ostro-image.bb
@@ -192,7 +192,7 @@ NOISO = "1"
 
 # Replace the default "live" (aka HDDIMG) images with whole-disk images
 # XXX Drop the VM hack after taking care also of the non UEFI devices (those using U-Boot: edison and beaglebone)
-OSTRO_VM_IMAGE_TYPES ?= "dsk dsk_xz dsk.vdi"
+OSTRO_VM_IMAGE_TYPES ?= "dsk dsk.xz dsk.vdi"
 IMAGE_FSTYPES_remove_intel-core2-32 = "live"
 IMAGE_FSTYPES_append_intel-core2-32 = " ${OSTRO_VM_IMAGE_TYPES}"
 IMAGE_FSTYPES_remove_intel-corei7-64 = "live"


### PR DESCRIPTION
This is functionally equivalent to PR #19, but leverages conversion
chaining from OE-core to achieve the same functionality with less
code. This also allows us to use the more natural and user-friendly
dsk.xz (instead of dsk_xz) IMAGE_FSTYPE.

Other benefits:
- all other compression methods also work ("dsk.bz2 dsk.lz4 ...")
- dependencies on the native tools are only added if really
  required
- RM_OLD_IMAGE works for image files

The code can also be made even simpler after enhancing OE-core further.
It is safe to merge this code, too, enhancing OE-core can be done so that
there are no conflicts with the changes in this PR. Both is demonstrated
by https://github.com/pohly/ostro-os/tree/image-compression