### PR TITLE
To support nfc and add neard to image

### DIFF
--- a/meta-ostro/recipes-core/packagegroups/packagegroup-core-connectivity.bb
+++ b/meta-ostro/recipes-core/packagegroups/packagegroup-core-connectivity.bb
@@ -11,4 +11,5 @@ RDEPENDS_${PN} = "\
     connman \
     connman-client \
     lowpan-tools \
+    neard \
     "


### PR DESCRIPTION
neard is the daemon of linux-nfc.
To support nfc, neard is needed.

Signed-off-by: Wu Zheng <wu.zheng@intel.com>