### PR TITLE
ostro.conf: re-enable python3-* recipes

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -265,8 +265,6 @@ PNBLACKLIST_INITRAMFS_BOOT = "Only used on Edison."
 PNBLACKLIST[initramfs-boot] = "${PNBLACKLIST_INITRAMFS_BOOT}"
 
 # Fixes pending upstream, disabled here because we don't need them.
-PNBLACKLIST[python3-setuptools] = "Has undesired (and probably unneeded) machine-dependency"
-PNBLACKLIST[python3-pip] = "Depends on unavailable python3-setuptools"
 PNBLACKLIST[lttng-tools] = "Has undesired machine-dependency"
 PNBLACKLIST[meta-ide-support] = "Has undesired machine-dependency"
 PNBLACKLIST[oprofile] = "Has undesired machine-dependency"


### PR DESCRIPTION
python3-setuptools and python3-pip were PNBLACKLISTed due to errors detected by
oeqa.selftest.iotsstatetests.SStateTests tests for edison vs. intel-core2-32
machines.

python3-setuptools is now needed by the new version of python-gobject recipe so
we need it enabled.

It is possible to just remove the PNBLACKLIST since we have split edison to it's
own package architecture (i.e., not sharing anything with core2-32) AND we are
no longer building with MACHINE=intel-core2-32.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>