### PR TITLE
ostro.conf: Set libmicrohttpd preferred version

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -212,6 +212,9 @@ PNWHITELIST_meta-soletta += " \
     graphviz \
 "
 
+# Soletta requires minimum 0.9.43 to build it with http server support
+PREFERRED_VERSION_libmicrohttpd ?= "0.9.43"
+
 # Java bootstrapping
 PREFERRED_PROVIDER_virtual/java-initial-native = "cacao-initial-native"
 PREFERRED_PROVIDER_virtual/java-native = "jamvm-native"


### PR DESCRIPTION
To build Soletta with http server support the libmicrohttpd
should be the 0.9.43 or newer.

Signed-off-by: Bruno Bottazzini <bruno.bottazzini@intel.com>