### PR TITLE
Set defaults for both local development and CI

### DIFF
--- a/meta-ostro/conf/distro/include/ostroproject-ci.inc
+++ b/meta-ostro/conf/distro/include/ostroproject-ci.inc
@@ -1,0 +1,5 @@
+# XXX Drop the VM hack after taking care also of the non UEFI devices (those using U-Boot: edison and beaglebone)
+OSTRO_VM_IMAGE_TYPES = "dsk.zip dsk.vdi.zip"
+
+# Include the devel settings
+require conf/distro/include/ostro-os-development.inc

--- a/meta-ostro/recipes-image/images/ostro-image.bb
+++ b/meta-ostro/recipes-image/images/ostro-image.bb
@@ -182,7 +182,7 @@ COMPRESS_DEPENDS_zip = "zip-native"
 
 # Replace the default "live" (aka HDDIMG) images with whole-disk images
 # XXX Drop the VM hack after taking care also of the non UEFI devices (those using U-Boot: edison and beaglebone)
-OSTRO_VM_IMAGE_TYPES ?= "dsk dsk.xz dsk.vdi"
+OSTRO_VM_IMAGE_TYPES ?= "dsk dsk.vdi"
 IMAGE_FSTYPES_remove_intel-core2-32 = "live"
 IMAGE_FSTYPES_append_intel-core2-32 = " ${OSTRO_VM_IMAGE_TYPES}"
 IMAGE_FSTYPES_remove_intel-corei7-64 = "live"


### PR DESCRIPTION
An individual developer is probably not interested in producing
compressed images.

Instead, it is more likely to use images that are deployable either
on the target or in a Virtual Machine, therefore do not waste
time/space compressing them by default.

This can be configured in:

meta-ostro/conf/distro/include/ostro-os-development.inc
meta-ostro/conf/distro/include/ostro-os-production.inc

The Continuous Integration infrastructure, otoh, wants to
produce only images that are convenient to download.

This can be configured in:

meta-ostro/conf/distro/include/ostroproject-ci.inc

Signed-off-by: Igor Stoppa <igor.stoppa@intel.com>