### PR TITLE
local.conf.sample: remove QEMU and add BeagleBone machines

### DIFF
--- a/meta-ostro/conf/conf-notes.txt
+++ b/meta-ostro/conf/conf-notes.txt
@@ -6,4 +6,6 @@ Common targets are:
     adt-installer
     meta-ide-support
 
-You can also run generated qemu images with a command like 'runqemu qemux86'
+We recommend to use VirtualBox if you wish to run an Ostro image in a
+virtual environment. Please check the doc/howtos/booting-and-installation.rst
+technical note for more information.

--- a/meta-ostro/conf/local.conf.sample
+++ b/meta-ostro/conf/local.conf.sample
@@ -15,16 +15,7 @@
 # Machine Selection
 #
 # You need to select a specific machine to target the build with. There are a selection
-# of emulated machines available which can boot and run in the QEMU emulator:
-#
-#MACHINE ?= "qemuarm"
-#MACHINE ?= "qemuarm64"
-#MACHINE ?= "qemumips"
-#MACHINE ?= "qemuppc"
-#MACHINE ?= "qemux86"
-#MACHINE ?= "qemux86-64"
-#
-# In addition, several real hardware platforms are supported.
+# of several hardware platforms that are supported:
 #
 # For MinnowBoard and Gigabyte GB-BXBT-3825:
 #MACHINE ?= "intel-corei7-64"
@@ -34,6 +25,9 @@
 #
 # For Intel Edison:
 #MACHINE ?= "edison"
+#
+# For BeagleBone Black:
+#MACHINE ?= "beaglebone"
 #
 # This sets the default machine to be "intel-corei7-64" if no other machine is selected:
 MACHINE ??= "intel-corei7-64"
@@ -153,10 +147,9 @@ PACKAGE_CLASSES ?= "package_ipk"
 # When using ssh to access such a developer image, ssh will typically
 # complain about the ssh host key because it gets re-created anew on
 # the device the first time ssh is used. To avoid this, one can
-# disable this check when invoking ssh (example IP address is from
-# local networking with qemu):
+# disable this check when invoking ssh:
 #
-# ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@192.168.7.2
+# ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@<ip-os-ostro-device>
 #
 # On devices with little entropy, generating the ssh host key can take
 # some time. This can be avoided by copying a generated host key off the
@@ -184,16 +177,6 @@ PACKAGE_CLASSES ?= "package_ipk"
 # NOTE: mklibs also needs to be explicitly enabled for a given image, see local.conf.extended
 USER_CLASSES ?= "buildstats image-mklibs image-prelink"
 
-
-#
-# Runtime testing of images
-#
-# The build system can test booting virtual machine images under qemu (an emulator)
-# after any root filesystems are created and run tests against those images. To
-# enable this uncomment this line. See classes/testimage(-auto).bbclass for
-# further details.
-#TEST_IMAGE = "1"
-#
 # Interactive shell configuration
 #
 # Under certain circumstances the system may need input from you and to do this it 


### PR DESCRIPTION
- Remove instructions on how to build an image to be run on
QEMU as it is not supported (because of limitations in the
EFI implementation of QEMU)
- Add instructions how to build for BeagleBone and BeagleBone
Black boards.

[skip ci]

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>