### PR TITLE
add systemd service files to config 802.15.4 radio boards

### DIFF
--- a/meta-ostro/recipes-extended/ostro-6lowpan/files/ostro-6lowpan-start.sh
+++ b/meta-ostro/recipes-extended/ostro-6lowpan/files/ostro-6lowpan-start.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+if [ -z "$HWADDR" ]; then
+    HWADDR=`ip link show wpan0 | grep -e link/ieee802.15.4 | sed -e 's#^.*link/ieee802.15.4 \([0-9a-fA-F:]\+\) .*$#\1#g'`
+    if [ -z "$HWADDR" ]; then
+        HWADDR=`sed /etc/machine-id -e 's#\([0-9a-fA-F]\{2\}\)#\1:#g' | cut -d: -f1-8`
+    fi
+fi
+
+if [ -z "$PAN" ]; then
+    PAN=777
+fi
+
+if [ -z "$ADDR" ]; then
+    ADDR=`echo $HWADDR  | cut -d: -f7-8 | tr -d :`
+fi
+
+if [ -z "$CHANNEL" ]; then
+    CHANNEL=`iz listphy | grep -e "channels on page 0:" | sed -e 's#^.*channels on page 0: \([0-9a-fA-F:]\+\) .*$#\1#g'`
+fi
+
+if [ -z "$CHANNEL" ]; then
+    CHANNEL=11
+fi
+
+ip link set wpan0 address ${HWADDR}
+iz set wpan0 ${PAN} ${ADDR} ${CHANNEL}
+ifconfig wpan0 up
+ip link add link wpan0 name lowpan0 type lowpan
+ifconfig lowpan0 up
+

--- a/meta-ostro/recipes-extended/ostro-6lowpan/files/ostro-6lowpan-stop.sh
+++ b/meta-ostro/recipes-extended/ostro-6lowpan/files/ostro-6lowpan-stop.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+ifconfig lowpan0 down
+ifconfig wpan0 down
+ip link del lowpan0

--- a/meta-ostro/recipes-extended/ostro-6lowpan/files/ostro-6lowpan.service
+++ b/meta-ostro/recipes-extended/ostro-6lowpan/files/ostro-6lowpan.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=6loWPAN network setup
+Before=connman.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-/etc/ostro-6lowpan.conf
+ExecStart=/usr/lib/ostro-scripts/ostro-6lowpan-start.sh
+ExecStop=/usr/lib/ostro-scripts/ostro-6lowpan-stop.sh
+
+[Install]
+WantedBy=multi-user.target
+

--- a/meta-ostro/recipes-extended/ostro-6lowpan/ostro-6lowpan.bb
+++ b/meta-ostro/recipes-extended/ostro-6lowpan/ostro-6lowpan.bb
@@ -1,0 +1,27 @@
+#
+DESCRIPTION = "ostro-6lowpan systemd service"
+RDEPENDS_${PN} += "iproute2 lowpan-tools"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+PR = "r0"
+
+SRC_URI = "file://ostro-6lowpan.service \
+           file://ostro-6lowpan-start.sh \
+           file://ostro-6lowpan-stop.sh \
+           "
+
+FILES_${PN} += " ${systemd_unitdir}/system/ostro-6lowpan.service \
+                 ${libdir}/ostro-scripts/ostro-6lowpan-start.sh \
+                 ${libdir}/ostro-scripts/ostro-6lowpan-stop.sh \
+               "
+# Sample configuring file
+do_install_append () {
+	install -d -m 755 ${D}${systemd_unitdir}/system/
+	install -m 0644 ostro-6lowpan.service ${D}${systemd_unitdir}/system/
+	install -d -m 755 ${D}${libdir}/ostro-scripts/
+	install -m 0755 ostro-6lowpan-start.sh ${D}${libdir}/ostro-scripts/
+	install -m 0755 ostro-6lowpan-stop.sh ${D}${libdir}/ostro-scripts/
+}
+
+S = "${WORKDIR}"
+


### PR DESCRIPTION
In order to use the 802.15.4 radio boards, some commands are needed, add thme as systemd service:
	systemctl enable ostro-6lowpan
	systemctl start ostro-6lowpan

Signed-off-by: Yong Li <yong.b.li@intel.com>