### PR TITLE
local.conf.sample: remove Qemu configuration block

### DIFF
--- a/meta-ostro/conf/layer.conf
+++ b/meta-ostro/conf/layer.conf
@@ -17,7 +17,7 @@ BBFILE_PRIORITY_ostro = "6"
 # need to be increased by one each time a change is made to
 # local.conf.sample that requires manually updating a local.conf after
 # updating the meta data.
-LOCALCONF_VERSION = "1"
+LOCALCONF_VERSION = "2"
 
 # Same for LCONF_VERSION in bblayer.conf.sample.
 LAYER_CONF_VERSION = "7"

--- a/meta-ostro/conf/local.conf.sample
+++ b/meta-ostro/conf/local.conf.sample
@@ -232,22 +232,10 @@ BB_DISKMON_DIRS = "\
 # Example for Ostro OS setup, recommended to use it:
 #SSTATE_MIRRORS ?= "file://.* http://download.ostroproject.org/sstate/ostro-os/PATH"
 
-
-#
-# Qemu configuration
-#
-# By default qemu will build with a builtin VNC server where graphical output can be
-# seen. The two lines below enable the SDL backend too. This assumes there is a
-# libsdl library available on your build system.
-PACKAGECONFIG_append_pn-qemu-native = " sdl"
-PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
-ASSUME_PROVIDED += "libsdl-native"
-
-
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
 # track the version of this file when it was generated. This can safely be ignored if
 # this doesn't mean anything to you.
-CONF_VERSION = "1"
+CONF_VERSION = "2"
 
 #
 # ISAFW: https://github.com/01org/isafw


### PR DESCRIPTION
Remove the Qemu configuration block as QEMU is not supported
with Ostro due to its EFI implementation limitations

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>