### PR TITLE
Add gSSO framework and related dependencies

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -154,6 +154,7 @@ PNWHITELIST_openembedded-layer += " \
     can-utils \
     giflib \
     krb5 \
+    pkcs11-helper \
 "
 PNWHITELIST_perl-layer += ""
 PNWHITELIST_ruby-layer += ""

--- a/meta-ostro/recipes-security/ecryptfs-utils/ecryptfs-utils_110.bb
+++ b/meta-ostro/recipes-security/ecryptfs-utils/ecryptfs-utils_110.bb
@@ -1,0 +1,31 @@
+SUMMARY = "Library and utilities for managing eCryptFS filesystems"
+DESCRIPTION = "eCryptfs is a POSIX-compliant enterprise cryptographic stacked filesystem for Linux. eCryptfs stores cryptographic metadata in the header of each file, so that encrypted files can be copied between hosts; the file will be decrypted with the proper key in the Linux kernel keyring."
+
+# by default ecryptfs-utils builds against NSS, but can be switched to gcrypt
+DEPENDS = "virtual/gettext glib-2.0 keyutils nss"
+RDEPENDS_${PN} = "keyutils nss"
+
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=8ca43cbc842c2336e835926c2166c28b"
+
+SRC_URI = "https://launchpad.net/ecryptfs/trunk/110/+download/ecryptfs-utils_110.orig.tar.gz"
+SRC_URI[md5sum] = "3205ce74b2236ee7fe94509dc0fe3660"
+
+EXTRA_OECONF = "--disable-pywrap"
+
+PACKAGECONFIG ??= "openssl pkcs11-helper ${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'pam', '', d)}"
+PACKAGECONFIG[openssl] = "--enable-openssl,--disable-openssl,openssl"
+PACKAGECONFIG[pkcs11-helper] = "--enable-pkcs11-helper,--disable-pkcs11-helper,pkcs11-helper"
+PACKAGECONFIG[pam] = "--enable-pam,--disable-pam,libpam"
+
+inherit pkgconfig autotools
+
+FILES_${PN} = " \
+	/sbin/*.ecryptfs* \
+	/usr/bin/ecryptfs* \
+	/usr/share/ecryptfs-utils \
+	/lib/security/pam_ecryptfs.so \
+	/usr/lib/libecryptfs.so* \
+	/usr/lib/ecryptfs \
+	"
+

--- a/meta-ostro/recipes-security/gsignond-plugin-oauth/gsignond-plugin-oauth_1.0.0.bb
+++ b/meta-ostro/recipes-security/gsignond-plugin-oauth/gsignond-plugin-oauth_1.0.0.bb
@@ -1,0 +1,23 @@
+SUMMARY = "OAuth plugin for gSSO"
+DESCRIPTION = "Plugin implementing OAuth functionality for gSSO framework"
+
+DEPENDS = "glib-2.0 gsignond json-glib gnutls libsoup-2.4"
+RDEPENDS_${PN} = "glib-2.0 gsignond json-glib gnutls libsoup-2.4"
+
+LICENSE = "LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c"
+
+SRC_URI = "git://gitlab.com/accounts-sso/gsignond-plugin-oa.git;protocol=https"
+SRCREV = "af3586017891ac8bdc7d81f519cbc8e9025f943e"
+
+S = "${WORKDIR}/git"
+
+inherit pkgconfig autotools gtk-doc
+
+do_install_append() {
+	rm ${D}/usr/lib/gsignond/gplugins/*.la
+}
+
+FILES_${PN} = " \
+	/usr/lib/gsignond/gplugins/liboauth.so \
+	"

--- a/meta-ostro/recipes-security/gsignond-plugin-sasl/gsignond-plugin-sasl_1.0.0.bb
+++ b/meta-ostro/recipes-security/gsignond-plugin-sasl/gsignond-plugin-sasl_1.0.0.bb
@@ -1,0 +1,23 @@
+SUMMARY = "SASL plugin for gSSO"
+DESCRIPTION = "Plugin implementing SASL functionality for gSSO framework"
+
+DEPENDS = "glib-2.0 gsignond libgsasl"
+RDEPENDS_${PN} = "glib-2.0 gsignond libgsasl"
+
+LICENSE = "LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c"
+
+SRC_URI = "git://gitlab.com/accounts-sso/gsignond-plugin-sasl.git;protocol=https"
+SRCREV = "de3630891e664de32bd77e34977b237785809e8d"
+
+S = "${WORKDIR}/git"
+
+inherit pkgconfig autotools gtk-doc
+
+do_install_append() {
+	rm ${D}/usr/lib/gsignond/gplugins/*.la
+}
+
+FILES_${PN} = " \
+	/usr/lib/gsignond/gplugins/libsasl.so \
+	"

--- a/meta-ostro/recipes-security/gsignond/gsignond_1.0.4.bb
+++ b/meta-ostro/recipes-security/gsignond/gsignond_1.0.4.bb
@@ -1,0 +1,36 @@
+SUMMARY = "gSSO daemon"
+DESCRIPTION = "GLib-based Single Sign-On daemon"
+
+DEPENDS = "glib-2.0 sqlite3 smack ecryptfs-utils"
+RDEPENDS_${PN} = "glib-2.0 sqlite3 ecryptfs-utils"
+
+LICENSE = "LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c"
+
+EXTRA_OECONF = "--enable-dbus-type=p2p"
+
+# keychain sysctx must be built in
+#EXTRA_OECONF_append = " --enable-keychain=XXX"
+
+SRC_URI = "git://gitlab.com/accounts-sso/gsignond.git;protocol=https"
+SRCREV = "b12650ac5b6dd64d9fa59cb01b497eb0a181ec53"
+
+S = "${WORKDIR}/git"
+
+inherit pkgconfig autotools gtk-doc
+
+do_install_append() {
+	rm ${D}/usr/lib/libgsignond*.la
+	rm ${D}/usr/lib/gsignond/extensions/*.la
+	rm ${D}/usr/lib/gsignond/gplugins/*.la
+}
+
+FILES_${PN} = " \
+	/usr/bin/gsignond \
+	/usr/lib/libgsignond*.so* \
+	/usr/lib/gsignond/extensions/*.so \
+	/usr/lib/gsignond/gplugins/*.so \
+	/usr/lib/gsignond/pluginloaders \
+	/etc/gsignond.conf \
+	/usr/share/dbus-1/interfaces/com.google.code.AccountsSSO.* \
+	"

--- a/meta-ostro/recipes-security/libgsasl/libgsasl/0001-configure.ac-add-missing-AM_PROG_AR.patch
+++ b/meta-ostro/recipes-security/libgsasl/libgsasl/0001-configure.ac-add-missing-AM_PROG_AR.patch
@@ -1,0 +1,28 @@
+From 4cecc5aa3b7f5edde7d3d07ff6c2ae029d04ab00 Mon Sep 17 00:00:00 2001
+From: Jussi Laako <jussi.laako@linux.intel.com>
+Date: Thu, 17 Mar 2016 16:18:30 +0200
+Subject: [PATCH] configure.ac: add missing AM_PROG_AR
+
+The provided configure.ac is missing AM_PROG_AR required by the automake
+version in use.
+
+Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>
+---
+ lib/configure.ac | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/configure.ac b/lib/configure.ac
+index 5f984de..d88b4fc 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -38,6 +38,7 @@ AC_SUBST(DLL_VERSION)
+ 
+ AM_INIT_AUTOMAKE([1.10 -Wall -Werror])
+ AM_SILENT_RULES([yes])
++AM_PROG_AR
+ AC_CONFIG_HEADERS([config.h])
+ 
+ # Checks for programs.
+-- 
+2.7.0
+

--- a/meta-ostro/recipes-security/libgsasl/libgsasl_1.8.0.bb
+++ b/meta-ostro/recipes-security/libgsasl/libgsasl_1.8.0.bb
@@ -1,0 +1,20 @@
+SUMMARY = "GNU SASL Library"
+DESCRIPTION = "GNU SASL is an implementation of the Simple Authentication and Security Layer framework and a few common SASL mechanisms. SASL is used by network servers (e.g., IMAP, SMTP) to request authentication from clients, and in clients to authenticate against servers."
+
+DEPENDS = "virtual/gettext libidn"
+RDEPENDS_${PN} = "libidn"
+
+LICENSE = "GPLv2+ & LGPLv2.1+"
+LIC_FILES_CHKSUM = " \
+	file://COPYING;md5=d32239bcb673463ab874e80d47fae504 \
+	file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
+	"
+
+SRC_URI = " \
+	ftp://ftp.gnu.org/gnu/gsasl/libgsasl-1.8.0.tar.gz \
+	file://0001-configure.ac-add-missing-AM_PROG_AR.patch \
+	"
+SRC_URI[md5sum] = "5dbdf859f6e60e05813370e2b193b92b"
+
+inherit pkgconfig autotools
+

--- a/meta-ostro/recipes-security/libgsignon-glib/libgsignon-glib_2.4.1.bb
+++ b/meta-ostro/recipes-security/libgsignon-glib/libgsignon-glib_2.4.1.bb
@@ -1,0 +1,25 @@
+SUMMARY = "gSSO client library"
+DESCRIPTION = "GLib-based client library for Single Sign-On daemon"
+
+DEPENDS = "glib-2.0"
+RDEPENDS_${PN} = "glib-2.0"
+
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=243b725d71bb5df4a1e5920b344b86ad"
+
+EXTRA_OECONF = "--enable-dbus-type=p2p --enable-vala=no --enable-introspection=no"
+
+SRC_URI = "git://gitlab.com/accounts-sso/libgsignon-glib.git;protocol=https"
+SRCREV = "9934e8fd036675d76ea751d2cea45521ff090ce8"
+
+S = "${WORKDIR}/git"
+
+inherit pkgconfig autotools gtk-doc
+
+do_install_append() {
+	rm -rf ${D}/usr/bin
+}
+
+FILES_${PN} = " \
+	/usr/lib/libgsignon-glib* \
+	"


### PR DESCRIPTION
Add recipes for gSSO framework, including daemon, client library and
plugins.

Also adds recipes for following dependency components:
	ecryptfs-utils
	libgsasl

Following new components are white-listed in ostro.conf:
	pkcs11-helper

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>