### PR TITLE
Make the default image fit on a 4GB SD card.

### DIFF
--- a/meta-ostro/classes/image-dsk.bbclass
+++ b/meta-ostro/classes/image-dsk.bbclass
@@ -83,7 +83,7 @@ DSK_IMAGE_LAYOUT ??= ' \
     "partition_03_rootfs": { \
         "name": "rootfs", \
         "uuid": "${ROOTFS_PARTUUID_VALUE}", \
-        "size_mb": 5000, \
+        "size_mb": 3800, \
         "source": "${IMAGE_ROOTFS}", \
         "filesystem": "ext4", \
         "type": "8300" \


### PR DESCRIPTION
The Ostro image doesn't use much space, even the devel
variant uses about 1.5GB.
Let's drop some free space from the default image layout,
so that the image produced can fit on a 4GB SD card.

Signed-off-by: Igor Stoppa <igor.stoppa@intel.com>