### PR TITLE
ostro.conf: enable uninative

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -306,3 +306,7 @@ INPUTANALYZER_WHITELIST = '/(meta|meta-yocto-bsp|meta-intel|meta-java|meta-oic|m
 # MASK incompatible .bbappends from meta-soletta. meta-soletta's systemd
 # .bbappend is in conflict with our needs.
 BBMASK = "meta-soletta/recipes-configure/systemd"
+
+# re-use uninative shim released by Yocto Project / OE
+require conf/distro/include/yocto-uninative.inc
+INHERIT += "uninative"


### PR DESCRIPTION
Enable usage of uninative feature for native components.
This would allow to re-use same native components across
different Linux distributions.
Config file comes from OE-Core, thus we can be sure that
it always points to corresponding to our state of OE-Core
shim glibc version, and this version already tested and
used within Yocto Project.

Signed-off-by: Alexander Kanevskiy <kad@linux.intel.com>