### PR TITLE
bblayers.conf versioning

### DIFF
--- a/meta-ostro/conf/bblayers.conf.sample
+++ b/meta-ostro/conf/bblayers.conf.sample
@@ -1,6 +1,6 @@
 # LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
 # changes incompatibly
-LCONF_VERSION = "5"
+LCONF_VERSION = "7"
 
 BBPATH = "${TOPDIR}"
 BBFILES ?= ""

--- a/meta-ostro/conf/layer.conf
+++ b/meta-ostro/conf/layer.conf
@@ -18,3 +18,6 @@ BBFILE_PRIORITY_ostro = "6"
 # local.conf.sample that requires manually updating a local.conf after
 # updating the meta data.
 LOCALCONF_VERSION = "1"
+
+# Same for LCONF_VERSION in bblayer.conf.sample.
+LAYER_CONF_VERSION = "7"

--- a/meta-ostro/conf/layer.conf
+++ b/meta-ostro/conf/layer.conf
@@ -21,3 +21,10 @@ LOCALCONF_VERSION = "1"
 
 # Same for LCONF_VERSION in bblayer.conf.sample.
 LAYER_CONF_VERSION = "7"
+
+# The default error messages use shell meta* wildcards to find the
+# conf files which in ostro-os happen to match two files (one from
+# meta and the real one from meta-ostro). Be more specific to avoid
+# user confusion.
+SANITY_LOCALCONF_SAMPLE = "${COREBASE}/meta-ostro/conf/local.conf.sample"
+SANITY_BBLAYERCONF_SAMPLE = "${COREBASE}/meta-ostro/conf/bblayers.conf.sample"


### PR DESCRIPTION
The first commit avoids the "NOTE: Your conf/bblayers.conf file has
been automatically updated." that each developer gets when starting to
use ostro-os.

The second commit relies on some changes currently staged in OE-core
master-next. It is already safe to merge now. However, whether we
really bump LAYER_CONF_VERSION when adding the next layer (most
likely, meta-swupd) remains to be seen.

Right now, automatically rewriting our bblayers.conf fails, and the
resulting error messages is very confusing
(https://bugzilla.yoctoproject.org/show_bug.cgi?id=9291 filed) for
users (quoted below). That depends on whether it is less confusing
than the error a developer gets when continuing to use an out-dated
bblayer.conf.

ERROR: Error executing a python function in exec_python_func() autogenerated:

The stack trace of python calls that resulted in this exception/failure was:
File: 'exec_python_func() autogenerated', lineno: 2, function: <module>
     0001:
 *** 0002:oecore_update_bblayers(d)
     0003:
File: '/work/ostro-os/meta/classes/sanity.bbclass', lineno: 168, function: oecore_update_bblayers
     0164:        current_lconf += 1
     0165:        sanity_conf_update(bblayers_fn, lines, 'LCONF_VERSION', current_lconf)
     0166:        return
     0167:
 *** 0168:    raise NotImplementedError(failmsg)
     0169:}
     0170:
     0171:def raise_sanity_error(msg, d, network_error=False):
     0172:    if d.getVar("SANITY_USE_EVENTS", True) == "1":
Exception: NotImplementedError: Your version of bblayers.conf has the wrong LCONF_VERSION (has 7, expecting 8).
Please compare your file against bblayers.conf.sample and merge any changes before continuing.
"meld conf/bblayers.conf /work/ostro-os/meta-ostro/conf/bblayers.conf.sample"

is a good way to visualise the changes.

ERROR: Execution of event handler 'check_sanity_eventhandler' failed
Traceback (most recent call last):
  File "/work/ostro-os/meta/classes/sanity.bbclass", line 956, in check_sanity(sanity_data=<bb.data_smart.DataSmart object at 0x7ff72ffdecd0>):
     
    >    check_sanity_everybuild(status, sanity_data)
         
  File "/work/ostro-os/meta/classes/sanity.bbclass", line 782, in check_sanity_everybuild(status=<SanityStatus object at 0x7ff72ffdea10>, d=<bb.data_smart.DataSmart object at 0x7ff72ffdecd0>):
     
    >    sanity_check_conffiles(status, d)
     
  File "/work/ostro-os/meta/classes/sanity.bbclass", line 562, in sanity_check_conffiles(status=<SanityStatus object at 0x7ff72ffdea10>, d=<bb.data_smart.DataSmart object at 0x7ff72ffdecd0>):
                 try:
    >                bb.build.exec_func(func, d)
                 except NotImplementedError as e:
  File "/work/ostro-os/bitbake/lib/bb/build.py", line 227, in exec_func(func='oecore_update_bblayers', d=<bb.data_smart.DataSmart object at 0x7ff72ffdecd0>, dirs=None):
             if ispython:
    >            exec_func_python(func, d, runfile, cwd=adir)
             else:
  File "/work/ostro-os/bitbake/lib/bb/build.py", line 263, in exec_func_python(func='oecore_update_bblayers', d=<bb.data_smart.DataSmart object at 0x7ff72ffdecd0>, runfile='/tmp/test/tmp-glibc/work/corei7-64-ostro-linux/defaultpkgname/1.0-r0/temp/run.oecore_update_bblayers.20343', cwd='/tmp/test/tmp-glibc/work/corei7-64-ostro-linux/defaultpkgname/1.0-r0/defaultpkgname-1.0'):
         except:
    >        raise FuncFailed(func, None)
         finally:
FuncFailed: Function failed: oecore_update_bblayers

ERROR: Command execution failed: Traceback (most recent call last):
  File "/work/ostro-os/bitbake/lib/bb/command.py", line 101, in runAsyncCommand
    self.cooker.updateCache()
  File "/work/ostro-os/bitbake/lib/bb/cooker.py", line 1538, in updateCache
    bb.event.fire(bb.event.SanityCheck(False), self.data)
  File "/work/ostro-os/bitbake/lib/bb/event.py", line 171, in fire
    fire_class_handlers(event, d)
  File "/work/ostro-os/bitbake/lib/bb/event.py", line 110, in fire_class_handlers
    execute_handler(name, handler, event, d)
  File "/work/ostro-os/bitbake/lib/bb/event.py", line 82, in execute_handler
    ret = handler(event)
  File "/work/ostro-os/meta/classes/sanity.bbclass", line 993, in check_sanity_eventhandler
    reparse = check_sanity(sanity_data)
  File "/work/ostro-os/meta/classes/sanity.bbclass", line 956, in check_sanity
    check_sanity_everybuild(status, sanity_data)
  File "/work/ostro-os/meta/classes/sanity.bbclass", line 782, in check_sanity_everybuild
    sanity_check_conffiles(status, d)
  File "/work/ostro-os/meta/classes/sanity.bbclass", line 562, in sanity_check_conffiles
    bb.build.exec_func(func, d)
  File "/work/ostro-os/bitbake/lib/bb/build.py", line 227, in exec_func
    exec_func_python(func, d, runfile, cwd=adir)
  File "/work/ostro-os/bitbake/lib/bb/build.py", line 263, in exec_func_python
    raise FuncFailed(func, None)
FuncFailed: Function failed: oecore_update_bblayers