### PR TITLE
ostro-image-dev: add dev-pkgs in IMAGE_FEATURES

### DIFF
--- a/meta-ostro/recipes-image/images/ostro-image.bb
+++ b/meta-ostro/recipes-image/images/ostro-image.bb
@@ -37,6 +37,7 @@ IMAGE_FEATURES[validitems] += " \
 # These features come from base recipes, but are not added to
 # IMAGE_FEATURES[validitems]. Should better be fixed there.
 IMAGE_FEATURES[validitems] += " \
+    dev-pkgs \
     ptest-pkgs \
     ssh-server-openssh \
     tools-debug \
@@ -49,6 +50,7 @@ IMAGE_FEATURES[validitems] += " \
 # avoids unnecessary proliferation of image variations that
 # need to be built automatically.
 IMAGE_VARIANT[dev] = " \
+    dev-pkgs \
     ptest-pkgs \
     tools-debug \
     tools-develop \


### PR DESCRIPTION
For a development image that installs all development tools, including
the compilers, it is also useful to have the -dev packages for all
components installed.

To get that, add "dev-pkgs" image feature in IMAGE_FEATURES for the
-dev variant.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>