### PR TITLE
libgsignon-glib: explicitly disable Python support

### DIFF
--- a/meta-ostro/recipes-security/libgsignon-glib/libgsignon-glib_2.4.1.bb
+++ b/meta-ostro/recipes-security/libgsignon-glib/libgsignon-glib_2.4.1.bb
@@ -7,7 +7,7 @@ RDEPENDS_${PN} = "glib-2.0"
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=243b725d71bb5df4a1e5920b344b86ad"
 
-EXTRA_OECONF = "--enable-dbus-type=p2p --enable-vala=no --enable-introspection=no"
+EXTRA_OECONF = "--enable-dbus-type=p2p --enable-vala=no --enable-introspection=no --disable-python"
 
 SRC_URI = "git://gitlab.com/accounts-sso/libgsignon-glib.git;protocol=https"
 SRCREV = "9934e8fd036675d76ea751d2cea45521ff090ce8"


### PR DESCRIPTION
In some cases, build of Python support becomes auto-enabled causing
build failure.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>