### PR TITLE
ostro.conf: switch preferred kernel version to 4.4

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -58,9 +58,10 @@ DISTRO_FEATURES_DEFAULT_remove = "x11 3g"
 
 DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_LIBC} ${OSTRO_DEFAULT_DISTRO_FEATURES}"
 
-# Use 4.1 kernel for all MACHINEs
-PREFERRED_VERSION_linux-yocto_intel-corei7-64 ?= "4.1%"
-PREFERRED_VERSION_linux-yocto_intel-quark ?= "4.1%"
+# Use 4.4 kernel for meta-intel BSP MACHINEs
+# BeagleBone is still on 4.1 until meta-yocto-bsp switches it over
+PREFERRED_VERSION_linux-yocto_intel-corei7-64 ?= "4.4%"
+PREFERRED_VERSION_linux-yocto_intel-quark ?= "4.4%"
 PREFERRED_VERSION_linux-yocto_beaglebone ?= "4.1%"
 
 DISTRO_EXTRA_RDEPENDS += " ${OSTRO_DEFAULT_EXTRA_RDEPENDS}"


### PR DESCRIPTION
Switch preferred kernel version to 4.4 for meta-intel BSP machines.
Reduces need for backport patches.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>