### PR TITLE
Virtualbox appliance generation

### DIFF
--- a/meta-ostro/classes/ostro-image.bbclass
+++ b/meta-ostro/classes/ostro-image.bbclass
@@ -238,7 +238,7 @@ COMPRESS_DEPENDS_zip = "zip-native"
 
 # Replace the default "live" (aka HDDIMG) images with whole-disk images
 # XXX Drop the VM hack after taking care also of the non UEFI devices (those using U-Boot: edison and beaglebone)
-OSTRO_VM_IMAGE_TYPES ?= "dsk dsk.vdi"
+OSTRO_VM_IMAGE_TYPES ?= "dsk dsk.vdi dsk.ova"
 IMAGE_FSTYPES_remove_intel-core2-32 = "live"
 IMAGE_FSTYPES_append_intel-core2-32 = " ${OSTRO_VM_IMAGE_TYPES}"
 IMAGE_FSTYPES_remove_intel-corei7-64 = "live"

--- a/meta-ostro/conf/bblayers.conf.sample
+++ b/meta-ostro/conf/bblayers.conf.sample
@@ -34,7 +34,7 @@ OSTRO_LAYERS = " \
 
 # OSTRO_LAYERS += "##OEROOT##/meta-openembedded/meta-efl"
 # OSTRO_LAYERS += "##OEROOT##/meta-openembedded/meta-filesystems"
-# OSTRO_LAYERS += "##OEROOT##/meta-openembedded/meta-gnome"
+OSTRO_LAYERS += "##OEROOT##/meta-openembedded/meta-gnome"
 # OSTRO_LAYERS += "##OEROOT##/meta-openembedded/meta-gpe"
 # OSTRO_LAYERS += "##OEROOT##/meta-openembedded/meta-initramfs"
 # OSTRO_LAYERS += "##OEROOT##/meta-openembedded/meta-multimedia"

--- a/meta-ostro/conf/distro/include/ostroproject-ci.inc
+++ b/meta-ostro/conf/distro/include/ostroproject-ci.inc
@@ -36,7 +36,7 @@ require conf/distro/include/ostro-os-development.inc
 
 # XXX Drop the VM hack after taking care also of the non UEFI devices
 # (those using U-Boot: edison and beaglebone)
-OSTRO_VM_IMAGE_TYPES = "dsk.xz dsk.zip dsk.vdi.zip dsk.ova dsk.bmap dsk.xz.sha256sum dsk.vdi.zip.sha256sum"
+OSTRO_VM_IMAGE_TYPES = "dsk.xz dsk.zip dsk.ova dsk.bmap dsk.xz.sha256sum"
 
 #
 # Automated build targets

--- a/meta-ostro/conf/distro/include/ostroproject-ci.inc
+++ b/meta-ostro/conf/distro/include/ostroproject-ci.inc
@@ -36,7 +36,7 @@ require conf/distro/include/ostro-os-development.inc
 
 # XXX Drop the VM hack after taking care also of the non UEFI devices
 # (those using U-Boot: edison and beaglebone)
-OSTRO_VM_IMAGE_TYPES = "dsk.xz dsk.zip dsk.vdi.zip dsk.bmap dsk.xz.sha256sum dsk.vdi.zip.sha256sum"
+OSTRO_VM_IMAGE_TYPES = "dsk.xz dsk.zip dsk.vdi.zip dsk.ova dsk.bmap dsk.xz.sha256sum dsk.vdi.zip.sha256sum"
 
 #
 # Automated build targets

--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -144,7 +144,7 @@ DISTRO_EXTRA_RRECOMMENDS += " ${OSTRO_DEFAULT_EXTRA_RRECOMMENDS}"
 QEMU_TARGETS ?= "arm i386 x86_64"
 
 # Set PREMIRRORS to prioritize Ostro OS autobuilder source cache.
-# The OSTRO_SOURCE_MIRROR_URL can be overriden in local.conf. 
+# The OSTRO_SOURCE_MIRROR_URL can be overriden in local.conf.
 OSTRO_SOURCE_MIRROR_URL ??= "https://download.ostroproject.org/mirror/sources/"
 SOURCE_MIRROR_URL = "${OSTRO_SOURCE_MIRROR_URL}"
 INHERIT += "own-mirrors"
@@ -213,7 +213,9 @@ PNWHITELIST_LAYERS = " \
 # instead of overwriting it.
 PNWHITELIST_efl-layer += ""
 PNWHITELIST_filesystems-layer += ""
-PNWHITELIST_gnome-layer += ""
+PNWHITELIST_gnome-layer += " \
+    libidl \
+"
 PNWHITELIST_gpe-layer += ""
 PNWHITELIST_meta-initramfs += ""
 PNWHITELIST_meta-python += " \
@@ -239,6 +241,7 @@ PNWHITELIST_openembedded-layer += " \
     libsocketcan \
     pkcs11-helper \
     vim \
+    acpica-native \
 "
 PNWHITELIST_perl-layer += ""
 PNWHITELIST_ruby-layer += ""

--- a/meta-ostro/recipes-core/makeself/makeself_2.2.0.bb
+++ b/meta-ostro/recipes-core/makeself/makeself_2.2.0.bb
@@ -1,0 +1,21 @@
+LICENSE="GPLv2"
+LIC_FILES_CHKSUM="file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+SRC_URI=" \
+    git://git@github.com/megastep/makeself.git;protocol=https \
+"	
+
+SRCREV="a16bc8c4eb4fc8abaa4ea847e051ba164df51f2a"
+
+S="${WORKDIR}/git"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/makeself.1 ${D}${bindir}/ 
+    install -m 0755 ${S}/makeself.lsm ${D}${bindir}/ 
+    install -m 0755 ${S}/makeself.sh ${D}${bindir}/ 
+    install -m 0755 ${S}/makeself-header.sh ${D}${bindir}/ 
+}
+
+
+BBCLASSEXTEND = "native"

--- a/meta-ostro/recipes-core/vboxmanage/files/configure.patch
+++ b/meta-ostro/recipes-core/vboxmanage/files/configure.patch
@@ -1,0 +1,68 @@
+Configure: Modify configurations
+
+Several libraries were not found, as the configure script was looking them
+from the system directories instead of Yocto sysroot. Additionally, disable the
+static libstdc++ check, as the component that depends on the libstdc++ will be
+disabled by another patch.
+
+Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>
+---
+ configure | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/configure b/configure
+index 237a86f..1be7be6 100755
+--- a/configure
++++ b/configure
+@@ -113,10 +113,10 @@ IASL="iasl"
+ XSLTPROC="xsltproc"
+ GENISOIMAGE="genisoimage"
+ MKISOFS="mkisofs"
+-INCCRYPTO=""
+-LIBCRYPTO="-lssl -lcrypto"
++INCCRYPTO="`pkg-config openssl --cflags`"
++LIBCRYPTO="`pkg-config openssl --libs` -Wl,-rpath=${libdir}"
+ LIBPTHREAD="-lpthread"
+-LIBCAP="-lcap"
++LIBCAP="`pkg-config libcap --cflags --libs` -Wl,-rpath=${libdir}"
+ GSOAP=""
+ GSOAP_IMPORT=""
+ INCX11="/usr/local/include"
+@@ -127,8 +127,8 @@ LIBXINERAMA="-lXinerama"
+ LIBXRANDR="-lXrandr"
+ MAKESELF="makeself"
+ MESA="-lGL"
+-INCZ=""
+-LIBZ="-lz"
++INCZ="`pkg-config zlib --cflags`"
++LIBZ="`pkg-config zlib --libs` -Wl,-rpath=${libdir}"
+ INCVNCSERVER=""
+ LIBVNCSERVER="-lvncserver"
+ INCDEVMAPPER=""
+@@ -142,10 +142,10 @@ if [ "$OS" = "freebsd" ]; then
+   INCPNG="-I/usr/local/include"
+   LIBPNG="-L/usr/local/lib -lpng"
+ else
+-  INCCURL=""
+-  LIBCURL="-lcurl"
+-  INCPNG=""
+-  LIBPNG="-lpng"
++  INCCURL="`pkg-config libcurl --cflags`"
++  LIBCURL="`pkg-config libcurl  --libs` -Wl,-rpath=${libdir}"
++  INCPNG="`pkg-config libpng --cflags`"
++  LIBPNG="`pkg-config libpng --libs` -Wl,-rpath=${libdir}"
+ fi
+ INCVPX=""
+ LIBVPX="-lvpx"
+@@ -2757,7 +2757,7 @@ fi
+ if [ "$OS" = "linux" ]; then
+   # don't check for the static libstdc++ in the PUEL version as we build the
+   # additions at a dedicated box
+-  [ $OSE -ge 1 ] && check_staticlibstdcxx
++  # [ $OSE -ge 1 ] && check_staticlibstdcxx
+   if [ $WITH_KMODS -eq 1 ]; then
+     check_linux
+   else
+--
+2.5.5
+

--- a/meta-ostro/recipes-core/vboxmanage/files/disable-guest-additions.patch
+++ b/meta-ostro/recipes-core/vboxmanage/files/disable-guest-additions.patch
@@ -1,0 +1,45 @@
+src/Vbox/Makefile.kmk: Disable Guest additions
+
+Guest additions requires libstdc++.a to compile, which isn't provided by
+Yocto libraries (no native gcc components available). As guest additions are
+not required for VBoxManage, just disable them.
+
+Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>
+---
+ src/VBox/Makefile.kmk | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/VBox/Makefile.kmk b/src/VBox/Makefile.kmk
+index 7f86b7a..52f14f5 100644
+--- a/src/VBox/Makefile.kmk
++++ b/src/VBox/Makefile.kmk
+@@ -26,7 +26,7 @@ ifdef VBOX_ONLY_ADDITIONS
+    include $(PATH_SUB_CURRENT)/GuestHost/Makefile.kmk
+   endif
+  endif
+- include $(PATH_SUB_CURRENT)/Additions/Makefile.kmk
++ # include $(PATH_SUB_CURRENT)/Additions/Makefile.kmk
+
+ else ifdef VBOX_ONLY_DOCS
+  include $(PATH_SUB_CURRENT)/Runtime/Makefile.kmk
+@@ -58,7 +58,7 @@ else ifdef VBOX_ONLY_SDK
+ else ifdef VBOX_ONLY_VALIDATIONKIT
+  include $(PATH_SUB_CURRENT)/Runtime/Makefile.kmk
+  include $(PATH_SUB_CURRENT)/HostDrivers/Makefile.kmk
+- include $(PATH_SUB_CURRENT)/Additions/Makefile.kmk
++ # include $(PATH_SUB_CURRENT)/Additions/Makefile.kmk
+  include $(PATH_SUB_CURRENT)/Disassembler/Makefile.kmk
+  include $(PATH_SUB_CURRENT)/ValidationKit/Makefile.kmk
+
+@@ -88,7 +88,7 @@ else
+   include $(PATH_SUB_CURRENT)/GuestHost/Makefile.kmk
+  endif
+  ifdef VBOX_WITH_ADDITIONS
+-  include $(PATH_SUB_CURRENT)/Additions/Makefile.kmk
++ # include $(PATH_SUB_CURRENT)/Additions/Makefile.kmk
+  endif
+  ifdef VBOX_WITH_VALIDATIONKIT
+   include $(PATH_SUB_CURRENT)/ValidationKit/Makefile.kmk
+--
+2.5.5
+

--- a/meta-ostro/recipes-core/vboxmanage/files/fix-linker-flags.patch
+++ b/meta-ostro/recipes-core/vboxmanage/files/fix-linker-flags.patch
@@ -1,0 +1,354 @@
+Compilers: Fix linker flags
+
+Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>
+---
+ kBuild/tools/GCC.kmk        | 4 ++--
+ kBuild/tools/GCC3.kmk       | 4 ++--
+ kBuild/tools/GCC32.kmk      | 4 ++--
+ kBuild/tools/GCC3PLAIN.kmk  | 4 ++--
+ kBuild/tools/GCC42MACHO.kmk | 4 ++--
+ kBuild/tools/GCC4MACHO.kmk  | 4 ++--
+ kBuild/tools/GCC64.kmk      | 4 ++--
+ kBuild/tools/GXX.kmk        | 4 ++--
+ kBuild/tools/GXX3.kmk       | 4 ++--
+ kBuild/tools/GXX32.kmk      | 4 ++--
+ kBuild/tools/GXX3OMF.kmk    | 4 ++--
+ kBuild/tools/GXX3PLAIN.kmk  | 4 ++--
+ kBuild/tools/GXX42MACHO.kmk | 4 ++--
+ kBuild/tools/GXX4MACHO.kmk  | 4 ++--
+ kBuild/tools/GXX64.kmk      | 4 ++--
+ 15 files changed, 30 insertions(+), 30 deletions(-)
+
+diff --git a/kBuild/tools/GCC.kmk b/kBuild/tools/GCC.kmk
+index 428f444..f597bf6 100644
+--- a/kBuild/tools/GCC.kmk
++++ b/kBuild/tools/GCC.kmk
+@@ -203,7 +203,7 @@ TOOL_GCC_LINK_PROGRAM_OUTPUT =
+ TOOL_GCC_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$(subst /,x,$(lib))),, $(lib)))
+ TOOL_GCC_LINK_PROGRAM_DEPORD =
+ define TOOL_GCC_LINK_PROGRAM_CMDS
+-	$(QUIET)$(TOOL_GCC_LD) $(flags) -o $(out) $(objs) \
++	$(QUIET)$(TOOL_GCC_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out) $(objs) \
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
+ endef
+
+@@ -225,7 +225,7 @@ TOOL_GCC_LINK_DLL_OUTPUT =
+ TOOL_GCC_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$(subst /,x,$(lib))),, $(lib)))
+ TOOL_GCC_LINK_DLL_DEPORD =
+ define TOOL_GCC_LINK_DLL_CMDS
+-	$(QUIET)$(TOOL_GCC_LD) $(TOOL_GCC_LDFLAGS.dll) $(flags) -o $(out) $(objs) \
++	$(QUIET)$(TOOL_GCC_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GCC_LDFLAGS.dll) $(flags) -o $(out) $(objs) \
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
+ endef
+
+diff --git a/kBuild/tools/GCC3.kmk b/kBuild/tools/GCC3.kmk
+index c9a16f0..cd9ae38 100644
+--- a/kBuild/tools/GCC3.kmk
++++ b/kBuild/tools/GCC3.kmk
+@@ -268,7 +268,7 @@ TOOL_GCC3_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$
+ 		$(filter %.def, $(othersrc))
+ TOOL_GCC3_LINK_PROGRAM_DEPORD =
+ define TOOL_GCC3_LINK_PROGRAM_CMDS
+-	$(QUIET)$(TOOL_GCC3_LD) $(flags) -o $(out) $(objs)\
++	$(QUIET)$(TOOL_GCC3_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out) $(objs)\
+ 		$(filter %.def, $(othersrc))\
+ 		$(foreach p,$(libpath), -L$(p))\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))\
+@@ -302,7 +302,7 @@ TOOL_GCC3_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$(sub
+ 		$(filter %.def, $(othersrc))
+ TOOL_GCC3_LINK_DLL_DEPORD =
+ define TOOL_GCC3_LINK_DLL_CMDS
+-	$(QUIET)$(TOOL_GCC3_LD) $(TOOL_GCC3_LDFLAGS.dll) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GCC3_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GCC3_LDFLAGS.dll) $(flags) -o $(out)\
+ 		$(if $(filter-out win os2, $(KBUILD_TARGET)),$(call TOOL_GCC3_LD_SONAME,$(target),$(out)))\
+ 		$(objs)\
+ 		$(filter %.def, $(othersrc))\
+diff --git a/kBuild/tools/GCC32.kmk b/kBuild/tools/GCC32.kmk
+index fc2b1fc..4a5dc87 100644
+--- a/kBuild/tools/GCC32.kmk
++++ b/kBuild/tools/GCC32.kmk
+@@ -263,7 +263,7 @@ TOOL_GCC32_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),
+ 		$(filter %.def, $(othersrc))
+ TOOL_GCC32_LINK_PROGRAM_DEPORD =
+ define TOOL_GCC32_LINK_PROGRAM_CMDS
+-	$(QUIET)$(TOOL_GCC32_LD) $(flags) -o $(out) $(objs)\
++	$(QUIET)$(TOOL_GCC32_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out) $(objs)\
+ 		$(foreach p,$(libpath), -L$(p))\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))\
+ 		$(call TOOL_GCC32_LD_MAP,$(outbase).map)
+@@ -296,7 +296,7 @@ TOOL_GCC32_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$(su
+ 		$(filter %.def, $(othersrc))
+ TOOL_GCC32_LINK_DLL_DEPORD =
+ define TOOL_GCC32_LINK_DLL_CMDS
+-	$(QUIET)$(TOOL_GCC32_LD) $(TOOL_GCC32_LDFLAGS.dll) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GCC32_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GCC32_LDFLAGS.dll) $(flags) -o $(out)\
+ 		$(if $(filter-out win os2, $(KBUILD_TARGET)),$(call TOOL_GCC32_LD_SONAME,$(target),$(out)))\
+ 		$(objs)\
+ 		$(foreach p,$(libpath), -L$(p))\
+diff --git a/kBuild/tools/GCC3PLAIN.kmk b/kBuild/tools/GCC3PLAIN.kmk
+index cad9324..aedc901 100644
+--- a/kBuild/tools/GCC3PLAIN.kmk
++++ b/kBuild/tools/GCC3PLAIN.kmk
+@@ -253,7 +253,7 @@ TOOL_GCC3PLAIN_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(l
+ 		$(filter %.def, $(othersrc))
+ TOOL_GCC3PLAIN_LINK_PROGRAM_DEPORD =
+ define TOOL_GCC3PLAIN_LINK_PROGRAM_CMDS
+-	$(QUIET)$(TOOL_GCC3PLAIN_LD) $(flags) -o $(out) $(objs)\
++	$(QUIET)$(TOOL_GCC3PLAIN_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out) $(objs)\
+ 		$(filter %.def, $(othersrc))\
+ 		$(foreach p,$(libpath), -L$(p))\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
+@@ -279,7 +279,7 @@ TOOL_GCC3PLAIN_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),
+ 		$(filter %.def, $(othersrc))
+ TOOL_GCC3PLAIN_LINK_DLL_DEPORD =
+ define TOOL_GCC3PLAIN_LINK_DLL_CMDS
+-	$(QUIET)$(TOOL_GCC3PLAIN_LD) $(TOOL_GCC3PLAIN_LDFLAGS.dll) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GCC3PLAIN_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GCC3PLAIN_LDFLAGS.dll) $(flags) -o $(out)\
+ 		$(if $(filter-out win32 os2, $(KBUILD_TARGET)),$(call TOOL_GCC3PLAIN_LD_SONAME,$(target),$(out)))\
+ 		$(objs)\
+ 		$(filter %.def, $(othersrc))\
+diff --git a/kBuild/tools/GCC42MACHO.kmk b/kBuild/tools/GCC42MACHO.kmk
+index 618ac75..ae7c60b 100644
+--- a/kBuild/tools/GCC42MACHO.kmk
++++ b/kBuild/tools/GCC42MACHO.kmk
+@@ -389,7 +389,7 @@ TOOL_GCC42MACHO_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(
+ TOOL_GCC42MACHO_LINK_PROGRAM_DEPORD =
+ define TOOL_GCC42MACHO_LINK_PROGRAM_CMDS
+ 	$(QUIET)$(APPEND) -n $(outbase).rsp $(objs)
+-	$(QUIET)$(TOOL_GCC42MACHO_LD) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GCC42MACHO_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out)\
+ 		-filelist $(outbase).rsp\
+ 		$(foreach p,$(libpath), -L$(p))\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
+@@ -421,7 +421,7 @@ TOOL_GCC42MACHO_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib)
+ TOOL_GCC42MACHO_LINK_DLL_DEPORD =
+ define TOOL_GCC42MACHO_LINK_DLL_CMDS
+ 	$(QUIET)$(APPEND) -n $(outbase).rsp $(objs)
+-	$(QUIET)$(TOOL_GCC42MACHO_LD) $(TOOL_GCC42MACHO_LDFLAGS.dll) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GCC42MACHO_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GCC42MACHO_LDFLAGS.dll) $(flags) -o $(out)\
+ 		$(call TOOL_GCC42MACHO_LD_SONAME,$(target),$(out))\
+ 		-filelist $(outbase).rsp\
+ 		$(foreach p,$(libpath), -L$(p))\
+diff --git a/kBuild/tools/GCC4MACHO.kmk b/kBuild/tools/GCC4MACHO.kmk
+index 2a0c91f..2ea43e1 100644
+--- a/kBuild/tools/GCC4MACHO.kmk
++++ b/kBuild/tools/GCC4MACHO.kmk
+@@ -389,7 +389,7 @@ TOOL_GCC4MACHO_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(l
+ TOOL_GCC4MACHO_LINK_PROGRAM_DEPORD =
+ define TOOL_GCC4MACHO_LINK_PROGRAM_CMDS
+ 	$(QUIET)$(APPEND) -n $(outbase).rsp $(objs)
+-	$(QUIET)$(TOOL_GCC4MACHO_LD) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GCC4MACHO_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out)\
+ 		-filelist $(outbase).rsp\
+ 		$(foreach p,$(libpath), -L$(p))\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
+@@ -421,7 +421,7 @@ TOOL_GCC4MACHO_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),
+ TOOL_GCC4MACHO_LINK_DLL_DEPORD =
+ define TOOL_GCC4MACHO_LINK_DLL_CMDS
+ 	$(QUIET)$(APPEND) -n $(outbase).rsp $(objs)
+-	$(QUIET)$(TOOL_GCC4MACHO_LD) $(TOOL_GCC4MACHO_LDFLAGS.dll) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GCC4MACHO_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GCC4MACHO_LDFLAGS.dll) $(flags) -o $(out)\
+ 		$(call TOOL_GCC4MACHO_LD_SONAME,$(target),$(out))\
+ 		-filelist $(outbase).rsp\
+ 		$(foreach p,$(libpath), -L$(p))\
+diff --git a/kBuild/tools/GCC64.kmk b/kBuild/tools/GCC64.kmk
+index 586f737..07d0ebd 100644
+--- a/kBuild/tools/GCC64.kmk
++++ b/kBuild/tools/GCC64.kmk
+@@ -258,7 +258,7 @@ TOOL_GCC64_LINK_PROGRAM_DEBUG_INSTALL_FN = $(2).debug=>$(basename $(3)).debug
+ TOOL_GCC64_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$(subst /,x,$(lib))),, $(lib)))
+ TOOL_GCC64_LINK_PROGRAM_DEPORD =
+ define TOOL_GCC64_LINK_PROGRAM_CMDS
+-	$(QUIET)$(TOOL_GCC64_LD) $(flags) -o $(out) $(objs)\
++	$(QUIET)$(TOOL_GCC64_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out) $(objs)\
+ 		$(foreach p,$(libpath), -L$(p))\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))\
+ 		$(call TOOL_GCC64_LD_MAP,$(outbase).map)
+@@ -290,7 +290,7 @@ TOOL_GCC64_LINK_DLL_DEBUG_INSTALL_FN = $(2).debug=>$(basename $(3)).debug
+ TOOL_GCC64_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$(subst /,x,$(lib))),, $(lib)))
+ TOOL_GCC64_LINK_DLL_DEPORD =
+ define TOOL_GCC64_LINK_DLL_CMDS
+-	$(QUIET)$(TOOL_GCC64_LD) $(TOOL_GCC64_LDFLAGS.dll) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GCC64_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GCC64_LDFLAGS.dll) $(flags) -o $(out)\
+ 		$(if $(filter-out win os2, $(KBUILD_TARGET)),$(call TOOL_GCC64_LD_SONAME,$(target),$(out)))\
+ 		$(objs)\
+ 		$(foreach p,$(libpath), -L$(p))\
+diff --git a/kBuild/tools/GXX.kmk b/kBuild/tools/GXX.kmk
+index 3f7c396..f40290d 100644
+--- a/kBuild/tools/GXX.kmk
++++ b/kBuild/tools/GXX.kmk
+@@ -203,7 +203,7 @@ TOOL_GXX_LINK_PROGRAM_OUTPUT =
+ TOOL_GXX_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$(subst /,x,$(lib))),, $(lib)))
+ TOOL_GXX_LINK_PROGRAM_DEPORD =
+ define TOOL_GXX_LINK_PROGRAM_CMDS
+-	$(QUIET)$(TOOL_GXX_LD) $(flags) -o $(out) $(objs) \
++	$(QUIET)$(TOOL_GXX_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out) $(objs) \
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
+ endef
+
+@@ -225,7 +225,7 @@ TOOL_GXX_LINK_DLL_OUTPUT =
+ TOOL_GXX_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$(subst /,x,$(lib))),, $(lib)))
+ TOOL_GXX_LINK_DLL_DEPORD =
+ define TOOL_GXX_LINK_DLL_CMDS
+-	$(QUIET)$(TOOL_GXX_LD) $(TOOL_GXX_LDFLAGS.dll) $(flags) -o $(out) $(objs) \
++	$(QUIET)$(TOOL_GXX_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GXX_LDFLAGS.dll) $(flags) -o $(out) $(objs) \
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
+ endef
+
+diff --git a/kBuild/tools/GXX3.kmk b/kBuild/tools/GXX3.kmk
+index 8664c8a..c6a92a0 100644
+--- a/kBuild/tools/GXX3.kmk
++++ b/kBuild/tools/GXX3.kmk
+@@ -268,7 +268,7 @@ TOOL_GXX3_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$
+ 		$(filter %.def, $(othersrc))
+ TOOL_GXX3_LINK_PROGRAM_DEPORD =
+ define TOOL_GXX3_LINK_PROGRAM_CMDS
+-	$(QUIET)$(TOOL_GXX3_LD) $(flags) -o $(out) $(objs)\
++	$(QUIET)$(TOOL_GXX3_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out) $(objs)\
+ 		$(filter %.def, $(othersrc))\
+ 		$(foreach p,$(libpath), -L$(p))\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))\
+@@ -302,7 +302,7 @@ TOOL_GXX3_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$(sub
+ 		$(filter %.def, $(othersrc))
+ TOOL_GXX3_LINK_DLL_DEPORD =
+ define TOOL_GXX3_LINK_DLL_CMDS
+-	$(QUIET)$(TOOL_GXX3_LD) $(TOOL_GXX3_LDFLAGS.dll) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GXX3_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GXX3_LDFLAGS.dll) $(flags) -o $(out)\
+ 		$(if $(filter-out win os2, $(KBUILD_TARGET)),$(call TOOL_GXX3_LD_SONAME,$(target),$(out)))\
+ 		$(objs)\
+ 		$(filter %.def, $(othersrc))\
+diff --git a/kBuild/tools/GXX32.kmk b/kBuild/tools/GXX32.kmk
+index 8e4b225..9638bd7 100644
+--- a/kBuild/tools/GXX32.kmk
++++ b/kBuild/tools/GXX32.kmk
+@@ -262,7 +262,7 @@ TOOL_GXX32_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),
+ 		$(filter %.def, $(othersrc))
+ TOOL_GXX32_LINK_PROGRAM_DEPORD =
+ define TOOL_GXX32_LINK_PROGRAM_CMDS
+-	$(QUIET)$(TOOL_GXX32_LD) $(flags) -o $(out) $(objs)\
++	$(QUIET)$(TOOL_GXX32_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out) $(objs)\
+ 		$(foreach p,$(libpath), -L$(p))\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))\
+ 		$(call TOOL_GXX32_LD_MAP,$(outbase).map)
+@@ -295,7 +295,7 @@ TOOL_GXX32_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$(su
+ 		$(filter %.def, $(othersrc))
+ TOOL_GXX32_LINK_DLL_DEPORD =
+ define TOOL_GXX32_LINK_DLL_CMDS
+-	$(QUIET)$(TOOL_GXX32_LD) $(TOOL_GXX32_LDFLAGS.dll) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GXX32_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GXX32_LDFLAGS.dll) $(flags) -o $(out)\
+ 		$(if $(filter-out win os2, $(KBUILD_TARGET)),$(call TOOL_GXX32_LD_SONAME,$(target),$(out)))\
+ 		$(objs)\
+ 		$(foreach p,$(libpath), -L$(p))\
+diff --git a/kBuild/tools/GXX3OMF.kmk b/kBuild/tools/GXX3OMF.kmk
+index b71f5e3..0c8214d 100644
+--- a/kBuild/tools/GXX3OMF.kmk
++++ b/kBuild/tools/GXX3OMF.kmk
+@@ -281,7 +281,7 @@ define TOOL_GXX3OMF_LINK_PROGRAM_CMDS
+ 		$(othersrc)\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))\
+ 		-Zmap=$(outbase).map
+-	$(QUIET)$(TOOL_GXX3OMF_LD) @$(outbase).rsp
++	$(QUIET)$(TOOL_GXX3OMF_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} @$(outbase).rsp
+ endef
+
+
+@@ -312,7 +312,7 @@ define TOOL_GXX3OMF_LINK_DLL_CMDS
+ 		$(othersrc)\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))\
+ 		-Zmap=$(outbase).map
+-	$(QUIET)$(TOOL_GXX3OMF_LD) @$(outbase).rsp
++	$(QUIET)$(TOOL_GXX3OMF_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} @$(outbase).rsp
+ endef
+
+
+diff --git a/kBuild/tools/GXX3PLAIN.kmk b/kBuild/tools/GXX3PLAIN.kmk
+index fd3d7f5..382de73 100644
+--- a/kBuild/tools/GXX3PLAIN.kmk
++++ b/kBuild/tools/GXX3PLAIN.kmk
+@@ -253,7 +253,7 @@ TOOL_GXX3PLAIN_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(l
+ 		$(filter %.def, $(othersrc))
+ TOOL_GXX3PLAIN_LINK_PROGRAM_DEPORD =
+ define TOOL_GXX3PLAIN_LINK_PROGRAM_CMDS
+-	$(QUIET)$(TOOL_GXX3PLAIN_LD) $(flags) -o $(out) $(objs)\
++	$(QUIET)$(TOOL_GXX3PLAIN_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out) $(objs)\
+ 		$(filter %.def, $(othersrc))\
+ 		$(foreach p,$(libpath), -L$(p))\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
+@@ -279,7 +279,7 @@ TOOL_GXX3PLAIN_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),
+ 		$(filter %.def, $(othersrc))
+ TOOL_GXX3PLAIN_LINK_DLL_DEPORD =
+ define TOOL_GXX3PLAIN_LINK_DLL_CMDS
+-	$(QUIET)$(TOOL_GXX3PLAIN_LD) $(TOOL_GXX3PLAIN_LDFLAGS.dll) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GXX3PLAIN_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GXX3PLAIN_LDFLAGS.dll) $(flags) -o $(out)\
+ 		$(if $(filter-out win32 os2, $(KBUILD_TARGET)),$(call TOOL_GXX3PLAIN_LD_SONAME,$(target),$(out)))\
+ 		$(objs)\
+ 		$(filter %.def, $(othersrc))\
+diff --git a/kBuild/tools/GXX42MACHO.kmk b/kBuild/tools/GXX42MACHO.kmk
+index 79a273f..ca34017 100644
+--- a/kBuild/tools/GXX42MACHO.kmk
++++ b/kBuild/tools/GXX42MACHO.kmk
+@@ -389,7 +389,7 @@ TOOL_GXX42MACHO_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(
+ TOOL_GXX42MACHO_LINK_PROGRAM_DEPORD =
+ define TOOL_GXX42MACHO_LINK_PROGRAM_CMDS
+ 	$(QUIET)$(APPEND) -n $(outbase).rsp $(objs)
+-	$(QUIET)$(TOOL_GXX42MACHO_LD) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GXX42MACHO_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out)\
+ 		-filelist $(outbase).rsp\
+ 		$(foreach p,$(libpath), -L$(p))\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
+@@ -420,7 +420,7 @@ TOOL_GXX42MACHO_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib)
+ TOOL_GXX42MACHO_LINK_DLL_DEPORD =
+ define TOOL_GXX42MACHO_LINK_DLL_CMDS
+ 	$(QUIET)$(APPEND) -n $(outbase).rsp $(objs)
+-	$(QUIET)$(TOOL_GXX42MACHO_LD) $(TOOL_GXX42MACHO_LDFLAGS.dll) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GXX42MACHO_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GXX42MACHO_LDFLAGS.dll) $(flags) -o $(out)\
+ 		$(call TOOL_GXX42MACHO_LD_SONAME,$(target),$(out))\
+ 		-filelist $(outbase).rsp\
+ 		$(foreach p,$(libpath), -L$(p))\
+diff --git a/kBuild/tools/GXX4MACHO.kmk b/kBuild/tools/GXX4MACHO.kmk
+index a455d56..6533876 100644
+--- a/kBuild/tools/GXX4MACHO.kmk
++++ b/kBuild/tools/GXX4MACHO.kmk
+@@ -389,7 +389,7 @@ TOOL_GXX4MACHO_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(l
+ TOOL_GXX4MACHO_LINK_PROGRAM_DEPORD =
+ define TOOL_GXX4MACHO_LINK_PROGRAM_CMDS
+ 	$(QUIET)$(APPEND) -n $(outbase).rsp $(objs)
+-	$(QUIET)$(TOOL_GXX4MACHO_LD) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GXX4MACHO_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out)\
+ 		-filelist $(outbase).rsp\
+ 		$(foreach p,$(libpath), -L$(p))\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))
+@@ -420,7 +420,7 @@ TOOL_GXX4MACHO_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),
+ TOOL_GXX4MACHO_LINK_DLL_DEPORD =
+ define TOOL_GXX4MACHO_LINK_DLL_CMDS
+ 	$(QUIET)$(APPEND) -n $(outbase).rsp $(objs)
+-	$(QUIET)$(TOOL_GXX4MACHO_LD) $(TOOL_GXX4MACHO_LDFLAGS.dll) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GXX4MACHO_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GXX4MACHO_LDFLAGS.dll) $(flags) -o $(out)\
+ 		$(call TOOL_GXX4MACHO_LD_SONAME,$(target),$(out))\
+ 		-filelist $(outbase).rsp\
+ 		$(foreach p,$(libpath), -L$(p))\
+diff --git a/kBuild/tools/GXX64.kmk b/kBuild/tools/GXX64.kmk
+index b1abc3f..f82df6b 100644
+--- a/kBuild/tools/GXX64.kmk
++++ b/kBuild/tools/GXX64.kmk
+@@ -258,7 +258,7 @@ TOOL_GXX64_LINK_PROGRAM_DEBUG_INSTALL_FN = $(2).debug=>$(basename $(3)).debug
+ TOOL_GXX64_LINK_PROGRAM_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$(subst /,x,$(lib))),, $(lib)))
+ TOOL_GXX64_LINK_PROGRAM_DEPORD =
+ define TOOL_GXX64_LINK_PROGRAM_CMDS
+-	$(QUIET)$(TOOL_GXX64_LD) $(flags) -o $(out) $(objs)\
++	$(QUIET)$(TOOL_GXX64_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(flags) -o $(out) $(objs)\
+ 		$(foreach p,$(libpath), -L$(p))\
+ 		$(foreach lib,$(libs), $(if $(findstring $(lib),$(subst /,x,$(lib))), -l$(patsubst lib%,%,$(lib)), $(lib)))\
+ 		$(call TOOL_GXX64_LD_MAP,$(outbase).map)
+@@ -290,7 +290,7 @@ TOOL_GXX64_LINK_DLL_DEBUG_INSTALL_FN = $(2).debug=>$(basename $(3)).debug
+ TOOL_GXX64_LINK_DLL_DEPEND = $(foreach lib,$(libs),$(if $(findstring $(lib),$(subst /,x,$(lib))),, $(lib)))
+ TOOL_GXX64_LINK_DLL_DEPORD =
+ define TOOL_GXX64_LINK_DLL_CMDS
+-	$(QUIET)$(TOOL_GXX64_LD) $(TOOL_GXX64_LDFLAGS.dll) $(flags) -o $(out)\
++	$(QUIET)$(TOOL_GXX64_LD) ${VIRTUALBOX_YOCTO_LDFLAGS} $(TOOL_GXX64_LDFLAGS.dll) $(flags) -o $(out)\
+ 		$(if $(filter-out win os2, $(KBUILD_TARGET)),$(call TOOL_GXX64_LD_SONAME,$(target),$(out)))\
+ 		$(objs)\
+ 		$(foreach p,$(libpath), -L$(p))\
+--
+1.9.1
+

--- a/meta-ostro/recipes-core/vboxmanage/files/include-dir.patch
+++ b/meta-ostro/recipes-core/vboxmanage/files/include-dir.patch
@@ -1,0 +1,885 @@
+Compiler scripts: Add Yocto include directory
+
+Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>
+---
+ kBuild/tools/GCC.kmk        |  6 +++---
+ kBuild/tools/GCC3.kmk       | 10 +++++-----
+ kBuild/tools/GCC32.kmk      | 10 +++++-----
+ kBuild/tools/GCC3OMF.kmk    | 12 ++++++------
+ kBuild/tools/GCC3PLAIN.kmk  | 10 +++++-----
+ kBuild/tools/GCC42MACHO.kmk | 18 +++++++++---------
+ kBuild/tools/GCC4MACHO.kmk  | 18 +++++++++---------
+ kBuild/tools/GXX.kmk        |  6 +++---
+ kBuild/tools/GXX3.kmk       | 10 +++++-----
+ kBuild/tools/GXX32.kmk      | 10 +++++-----
+ kBuild/tools/GXX3OMF.kmk    | 12 ++++++------
+ kBuild/tools/GXX3PLAIN.kmk  | 10 +++++-----
+ kBuild/tools/GXX42MACHO.kmk | 18 +++++++++---------
+ kBuild/tools/GXX4MACHO.kmk  | 18 +++++++++---------
+ kBuild/tools/GXX64.kmk      | 10 +++++-----
+ 15 files changed, 89 insertions(+), 89 deletions(-)
+
+diff --git a/kBuild/tools/GCC.kmk b/kBuild/tools/GCC.kmk
+index 482e421..428f444 100644
+--- a/kBuild/tools/GCC.kmk
++++ b/kBuild/tools/GCC.kmk
+@@ -97,7 +97,7 @@ TOOL_GCC_COMPILE_C_DEPEND =
+ TOOL_GCC_COMPILE_C_DEPORD =
+ define TOOL_GCC_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GCC_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) \
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -123,7 +123,7 @@ TOOL_GCC_COMPILE_CXX_DEPEND =
+ TOOL_GCC_COMPILE_CXX_DEPORD =
+ define TOOL_GCC_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GCC_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) \
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -149,7 +149,7 @@ TOOL_GCC_COMPILE_AS_DEPEND =
+ TOOL_GCC_COMPILE_AS_DEPORD =
+ define TOOL_GCC_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GCC_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) \
+ 		-o $(obj)\
+ 		$(abspath $(source))
+diff --git a/kBuild/tools/GCC3.kmk b/kBuild/tools/GCC3.kmk
+index fd6c6b8..c9a16f0 100644
+--- a/kBuild/tools/GCC3.kmk
++++ b/kBuild/tools/GCC3.kmk
+@@ -127,7 +127,7 @@ define TOOL_GCC3_COMPILE_C_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).i\
+ 		$(TOOL_GCC3_CC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -141,7 +141,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC3_COMPILE_C_OUTPUT =
+ define TOOL_GCC3_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GCC3_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -171,7 +171,7 @@ define TOOL_GCC3_COMPILE_CXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GCC3_CXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -185,7 +185,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC3_COMPILE_CXX_OUTPUT =
+ define TOOL_GCC3_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GCC3_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -212,7 +212,7 @@ TOOL_GCC3_COMPILE_AS_DEPEND =
+ TOOL_GCC3_COMPILE_AS_DEPORD =
+ define TOOL_GCC3_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GCC3_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+diff --git a/kBuild/tools/GCC32.kmk b/kBuild/tools/GCC32.kmk
+index 595e78a..fc2b1fc 100644
+--- a/kBuild/tools/GCC32.kmk
++++ b/kBuild/tools/GCC32.kmk
+@@ -122,7 +122,7 @@ define TOOL_GCC32_COMPILE_C_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).i\
+ 		$(TOOL_GCC32_CC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -136,7 +136,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC32_COMPILE_C_OUTPUT =
+ define TOOL_GCC32_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GCC32_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -166,7 +166,7 @@ define TOOL_GCC32_COMPILE_CXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GCC32_CXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -181,7 +181,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC32_COMPILE_CXX_OUTPUT =
+ define TOOL_GCC32_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GCC32_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -208,7 +208,7 @@ TOOL_GCC32_COMPILE_AS_DEPEND =
+ TOOL_GCC32_COMPILE_AS_DEPORD =
+ define TOOL_GCC32_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GCC32_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+diff --git a/kBuild/tools/GCC3OMF.kmk b/kBuild/tools/GCC3OMF.kmk
+index e7a97e8..383b580 100644
+--- a/kBuild/tools/GCC3OMF.kmk
++++ b/kBuild/tools/GCC3OMF.kmk
+@@ -114,7 +114,7 @@ define TOOL_GCC3OMF_COMPILE_C_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).i\
+ 		$(TOOL_GCC3OMF_CC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -128,7 +128,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC3OMF_COMPILE_C_OUTPUT =
+ define TOOL_GCC3OMF_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GCC3OMF_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP \
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -159,7 +159,7 @@ define TOOL_GCC3OMF_COMPILE_CXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GCC3OMF_CXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -173,7 +173,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC3OMF_COMPILE_CXX_OUTPUT =
+ define TOOL_GCC3OMF_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GCC3OMF_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP \
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -200,7 +200,7 @@ TOOL_GCC3OMF_COMPILE_AS_DEPEND =
+ TOOL_GCC3OMF_COMPILE_AS_DEPORD =
+ define TOOL_GCC3OMF_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GCC3OMF_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -226,7 +226,7 @@ TOOL_GCC3OMF_COMPILE_RC_DEPEND =
+ TOOL_GCC3OMF_COMPILE_RC_DEPORD =
+ define TOOL_GCC3OMF_COMPILE_RC_CMDS
+ 	$(QUIET)$(REDIRECT) -E 'INCLUDE=' -- $(TOOL_GCC3OMF_RC) -r \
+-		$(flags) $(addprefix -i, $(subst /,\\,$(subst /@unixroot,$(UNIXROOT),$(incs)))) $(addprefix -d, $(defs))\
++		$(flags) $(addprefix -i, $(subst /,\\,$(subst /@unixroot,$(UNIXROOT),$(incs)) -I${includedir})) $(addprefix -d, $(defs))\
+ 		$(subst /,\\,$(abspath $(source))) \
+ 		$(obj)
+ endef
+diff --git a/kBuild/tools/GCC3PLAIN.kmk b/kBuild/tools/GCC3PLAIN.kmk
+index 0793f83..cad9324 100644
+--- a/kBuild/tools/GCC3PLAIN.kmk
++++ b/kBuild/tools/GCC3PLAIN.kmk
+@@ -114,7 +114,7 @@ define TOOL_GCC3PLAIN_COMPILE_C_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).i\
+ 		$(TOOL_GCC3PLAIN_CC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -128,7 +128,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC3PLAIN_COMPILE_C_OUTPUT =
+ define TOOL_GCC3PLAIN_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GCC3PLAIN_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -158,7 +158,7 @@ define TOOL_GCC3PLAIN_COMPILE_CXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GCC3PLAIN_CXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -172,7 +172,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC3PLAIN_COMPILE_CXX_OUTPUT =
+ define TOOL_GCC3PLAIN_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GCC3PLAIN_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -199,7 +199,7 @@ TOOL_GCC3PLAIN_COMPILE_AS_DEPEND =
+ TOOL_GCC3PLAIN_COMPILE_AS_DEPORD =
+ define TOOL_GCC3PLAIN_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GCC3PLAIN_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+diff --git a/kBuild/tools/GCC42MACHO.kmk b/kBuild/tools/GCC42MACHO.kmk
+index d0f0a31..618ac75 100644
+--- a/kBuild/tools/GCC42MACHO.kmk
++++ b/kBuild/tools/GCC42MACHO.kmk
+@@ -161,7 +161,7 @@ define TOOL_GCC42MACHO_COMPILE_C_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).i\
+ 		$(TOOL_GCC42MACHO_CC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -175,7 +175,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC42MACHO_COMPILE_C_OUTPUT =
+ define TOOL_GCC42MACHO_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GCC42MACHO_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -205,7 +205,7 @@ define TOOL_GCC42MACHO_COMPILE_CXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GCC42MACHO_CXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -219,7 +219,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC42MACHO_COMPILE_CXX_OUTPUT =
+ define TOOL_GCC42MACHO_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GCC42MACHO_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -249,7 +249,7 @@ define TOOL_GCC42MACHO_COMPILE_OBJC_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GCC42MACHO_OBJC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -263,7 +263,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC42MACHO_COMPILE_OBJC_OUTPUT =
+ define TOOL_GCC42MACHO_COMPILE_OBJC_CMDS
+ 	$(QUIET)$(TOOL_GCC42MACHO_OBJC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -293,7 +293,7 @@ define TOOL_GCC42MACHO_COMPILE_OBJCXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).mii\
+ 		$(TOOL_GCC42MACHO_OBJCXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -307,7 +307,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC42MACHO_COMPILE_OBJCXX_OUTPUT =
+ define TOOL_GCC42MACHO_COMPILE_OBJCXX_CMDS
+ 	$(QUIET)$(TOOL_GCC42MACHO_OBJCXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -334,7 +334,7 @@ TOOL_GCC42MACHO_COMPILE_AS_DEPEND =
+ TOOL_GCC42MACHO_COMPILE_AS_DEPORD =
+ define TOOL_GCC42MACHO_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GCC42MACHO_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+diff --git a/kBuild/tools/GCC4MACHO.kmk b/kBuild/tools/GCC4MACHO.kmk
+index 307e2b1..2a0c91f 100644
+--- a/kBuild/tools/GCC4MACHO.kmk
++++ b/kBuild/tools/GCC4MACHO.kmk
+@@ -161,7 +161,7 @@ define TOOL_GCC4MACHO_COMPILE_C_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).i\
+ 		$(TOOL_GCC4MACHO_CC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -175,7 +175,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC4MACHO_COMPILE_C_OUTPUT =
+ define TOOL_GCC4MACHO_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GCC4MACHO_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -205,7 +205,7 @@ define TOOL_GCC4MACHO_COMPILE_CXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GCC4MACHO_CXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -219,7 +219,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC4MACHO_COMPILE_CXX_OUTPUT =
+ define TOOL_GCC4MACHO_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GCC4MACHO_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -249,7 +249,7 @@ define TOOL_GCC4MACHO_COMPILE_OBJC_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GCC4MACHO_OBJC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -263,7 +263,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC4MACHO_COMPILE_OBJC_OUTPUT =
+ define TOOL_GCC4MACHO_COMPILE_OBJC_CMDS
+ 	$(QUIET)$(TOOL_GCC4MACHO_OBJC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -293,7 +293,7 @@ define TOOL_GCC4MACHO_COMPILE_OBJCXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).mii\
+ 		$(TOOL_GCC4MACHO_OBJCXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -307,7 +307,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GCC4MACHO_COMPILE_OBJCXX_OUTPUT =
+ define TOOL_GCC4MACHO_COMPILE_OBJCXX_CMDS
+ 	$(QUIET)$(TOOL_GCC4MACHO_OBJCXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -334,7 +334,7 @@ TOOL_GCC4MACHO_COMPILE_AS_DEPEND =
+ TOOL_GCC4MACHO_COMPILE_AS_DEPORD =
+ define TOOL_GCC4MACHO_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GCC4MACHO_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+diff --git a/kBuild/tools/GXX.kmk b/kBuild/tools/GXX.kmk
+index c543238..3f7c396 100644
+--- a/kBuild/tools/GXX.kmk
++++ b/kBuild/tools/GXX.kmk
+@@ -97,7 +97,7 @@ TOOL_GXX_COMPILE_C_DEPEND =
+ TOOL_GXX_COMPILE_C_DEPORD =
+ define TOOL_GXX_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GXX_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) \
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -123,7 +123,7 @@ TOOL_GXX_COMPILE_CXX_DEPEND =
+ TOOL_GXX_COMPILE_CXX_DEPORD =
+ define TOOL_GXX_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GXX_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) \
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -149,7 +149,7 @@ TOOL_GXX_COMPILE_AS_DEPEND =
+ TOOL_GXX_COMPILE_AS_DEPORD =
+ define TOOL_GXX_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GXX_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) \
+ 		-o $(obj)\
+ 		$(abspath $(source))
+diff --git a/kBuild/tools/GXX3.kmk b/kBuild/tools/GXX3.kmk
+index 64cbd1d..8664c8a 100644
+--- a/kBuild/tools/GXX3.kmk
++++ b/kBuild/tools/GXX3.kmk
+@@ -127,7 +127,7 @@ define TOOL_GXX3_COMPILE_C_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).i\
+ 		$(TOOL_GXX3_CC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -141,7 +141,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX3_COMPILE_C_OUTPUT =
+ define TOOL_GXX3_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GXX3_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -171,7 +171,7 @@ define TOOL_GXX3_COMPILE_CXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GXX3_CXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -185,7 +185,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX3_COMPILE_CXX_OUTPUT =
+ define TOOL_GXX3_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GXX3_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -212,7 +212,7 @@ TOOL_GXX3_COMPILE_AS_DEPEND =
+ TOOL_GXX3_COMPILE_AS_DEPORD =
+ define TOOL_GXX3_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GXX3_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+diff --git a/kBuild/tools/GXX32.kmk b/kBuild/tools/GXX32.kmk
+index 49463d2..8e4b225 100644
+--- a/kBuild/tools/GXX32.kmk
++++ b/kBuild/tools/GXX32.kmk
+@@ -122,7 +122,7 @@ define TOOL_GXX32_COMPILE_C_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).i\
+ 		$(TOOL_GXX32_CC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -136,7 +136,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX32_COMPILE_C_OUTPUT =
+ define TOOL_GXX32_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GXX32_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -166,7 +166,7 @@ define TOOL_GXX32_COMPILE_CXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GXX32_CXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -180,7 +180,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX32_COMPILE_CXX_OUTPUT =
+ define TOOL_GXX32_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GXX32_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -207,7 +207,7 @@ TOOL_GXX32_COMPILE_AS_DEPEND =
+ TOOL_GXX32_COMPILE_AS_DEPORD =
+ define TOOL_GXX32_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GXX32_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+diff --git a/kBuild/tools/GXX3OMF.kmk b/kBuild/tools/GXX3OMF.kmk
+index f54b775..b71f5e3 100644
+--- a/kBuild/tools/GXX3OMF.kmk
++++ b/kBuild/tools/GXX3OMF.kmk
+@@ -114,7 +114,7 @@ define TOOL_GXX3OMF_COMPILE_C_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).i\
+ 		$(TOOL_GXX3OMF_CC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -128,7 +128,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX3OMF_COMPILE_C_OUTPUT =
+ define TOOL_GXX3OMF_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GXX3OMF_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP \
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -159,7 +159,7 @@ define TOOL_GXX3OMF_COMPILE_CXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GXX3OMF_CXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -173,7 +173,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX3OMF_COMPILE_CXX_OUTPUT =
+ define TOOL_GXX3OMF_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GXX3OMF_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP \
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -200,7 +200,7 @@ TOOL_GXX3OMF_COMPILE_AS_DEPEND =
+ TOOL_GXX3OMF_COMPILE_AS_DEPORD =
+ define TOOL_GXX3OMF_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GXX3OMF_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -226,7 +226,7 @@ TOOL_GXX3OMF_COMPILE_RC_DEPEND =
+ TOOL_GXX3OMF_COMPILE_RC_DEPORD =
+ define TOOL_GXX3OMF_COMPILE_RC_CMDS
+ 	$(QUIET)$(REDIRECT) -E 'INCLUDE=' -- $(TOOL_GXX3OMF_RC) -r \
+-		$(flags) $(addprefix -i, $(subst /,\\,$(subst /@unixroot,$(UNIXROOT),$(incs)))) $(addprefix -d, $(defs))\
++		$(flags) $(addprefix -i, $(subst /,\\,$(subst /@unixroot,$(UNIXROOT),$(incs)) -I${includedir})) $(addprefix -d, $(defs))\
+ 		$(subst /,\\,$(abspath $(source))) \
+ 		$(obj)
+ endef
+diff --git a/kBuild/tools/GXX3PLAIN.kmk b/kBuild/tools/GXX3PLAIN.kmk
+index 92ab12b..fd3d7f5 100644
+--- a/kBuild/tools/GXX3PLAIN.kmk
++++ b/kBuild/tools/GXX3PLAIN.kmk
+@@ -114,7 +114,7 @@ define TOOL_GXX3PLAIN_COMPILE_C_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).i\
+ 		$(TOOL_GXX3PLAIN_CC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -128,7 +128,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX3PLAIN_COMPILE_C_OUTPUT =
+ define TOOL_GXX3PLAIN_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GXX3PLAIN_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -158,7 +158,7 @@ define TOOL_GXX3PLAIN_COMPILE_CXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GXX3PLAIN_CXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -172,7 +172,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX3PLAIN_COMPILE_CXX_OUTPUT =
+ define TOOL_GXX3PLAIN_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GXX3PLAIN_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -199,7 +199,7 @@ TOOL_GXX3PLAIN_COMPILE_AS_DEPEND =
+ TOOL_GXX3PLAIN_COMPILE_AS_DEPORD =
+ define TOOL_GXX3PLAIN_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GXX3PLAIN_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+diff --git a/kBuild/tools/GXX42MACHO.kmk b/kBuild/tools/GXX42MACHO.kmk
+index df2077b..79a273f 100644
+--- a/kBuild/tools/GXX42MACHO.kmk
++++ b/kBuild/tools/GXX42MACHO.kmk
+@@ -161,7 +161,7 @@ define TOOL_GXX42MACHO_COMPILE_C_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).i\
+ 		$(TOOL_GXX42MACHO_CC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -175,7 +175,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX42MACHO_COMPILE_C_OUTPUT =
+ define TOOL_GXX42MACHO_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GXX42MACHO_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -205,7 +205,7 @@ define TOOL_GXX42MACHO_COMPILE_CXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GXX42MACHO_CXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -219,7 +219,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX42MACHO_COMPILE_CXX_OUTPUT =
+ define TOOL_GXX42MACHO_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GXX42MACHO_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -249,7 +249,7 @@ define TOOL_GXX42MACHO_COMPILE_OBJC_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GXX42MACHO_OBJC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -263,7 +263,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX42MACHO_COMPILE_OBJC_OUTPUT =
+ define TOOL_GXX42MACHO_COMPILE_OBJC_CMDS
+ 	$(QUIET)$(TOOL_GXX42MACHO_OBJC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -293,7 +293,7 @@ define TOOL_GXX42MACHO_COMPILE_OBJCXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).mii\
+ 		$(TOOL_GXX42MACHO_OBJCXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -307,7 +307,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX42MACHO_COMPILE_OBJCXX_OUTPUT =
+ define TOOL_GXX42MACHO_COMPILE_OBJCXX_CMDS
+ 	$(QUIET)$(TOOL_GXX42MACHO_OBJCXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -334,7 +334,7 @@ TOOL_GXX42MACHO_COMPILE_AS_DEPEND =
+ TOOL_GXX42MACHO_COMPILE_AS_DEPORD =
+ define TOOL_GXX42MACHO_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GXX42MACHO_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+diff --git a/kBuild/tools/GXX4MACHO.kmk b/kBuild/tools/GXX4MACHO.kmk
+index a3df1d5..a455d56 100644
+--- a/kBuild/tools/GXX4MACHO.kmk
++++ b/kBuild/tools/GXX4MACHO.kmk
+@@ -161,7 +161,7 @@ define TOOL_GXX4MACHO_COMPILE_C_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).i\
+ 		$(TOOL_GXX4MACHO_CC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -175,7 +175,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX4MACHO_COMPILE_C_OUTPUT =
+ define TOOL_GXX4MACHO_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GXX4MACHO_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -205,7 +205,7 @@ define TOOL_GXX4MACHO_COMPILE_CXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GXX4MACHO_CXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -219,7 +219,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX4MACHO_COMPILE_CXX_OUTPUT =
+ define TOOL_GXX4MACHO_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GXX4MACHO_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -249,7 +249,7 @@ define TOOL_GXX4MACHO_COMPILE_OBJC_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GXX4MACHO_OBJC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -263,7 +263,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX4MACHO_COMPILE_OBJC_OUTPUT =
+ define TOOL_GXX4MACHO_COMPILE_OBJC_CMDS
+ 	$(QUIET)$(TOOL_GXX4MACHO_OBJC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -293,7 +293,7 @@ define TOOL_GXX4MACHO_COMPILE_OBJCXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).mii\
+ 		$(TOOL_GXX4MACHO_OBJCXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -307,7 +307,7 @@ else  # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX4MACHO_COMPILE_OBJCXX_OUTPUT =
+ define TOOL_GXX4MACHO_COMPILE_OBJCXX_CMDS
+ 	$(QUIET)$(TOOL_GXX4MACHO_OBJCXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -334,7 +334,7 @@ TOOL_GXX4MACHO_COMPILE_AS_DEPEND =
+ TOOL_GXX4MACHO_COMPILE_AS_DEPORD =
+ define TOOL_GXX4MACHO_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GXX4MACHO_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+diff --git a/kBuild/tools/GXX64.kmk b/kBuild/tools/GXX64.kmk
+index 03973fc..b1abc3f 100644
+--- a/kBuild/tools/GXX64.kmk
++++ b/kBuild/tools/GXX64.kmk
+@@ -122,7 +122,7 @@ define TOOL_GXX64_COMPILE_C_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).i\
+ 		$(TOOL_GXX64_CC) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -136,7 +136,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX64_COMPILE_C_OUTPUT =
+ define TOOL_GXX64_COMPILE_C_CMDS
+ 	$(QUIET)$(TOOL_GXX64_CC) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -166,7 +166,7 @@ define TOOL_GXX64_COMPILE_CXX_CMDS
+ 	$(QUIET)$(KOBJCACHE) -f $(outbase).koc -d $(PATH_OBJCACHE) -t $(bld_trg).$(bld_trg_arch) -p\
+ 		--kObjCache-cpp $(outbase).ii\
+ 		$(TOOL_GXX64_CXX) -E -o -\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		$(abspath $(source))\
+ 		--kObjCache-cc $(obj)\
+@@ -180,7 +180,7 @@ else # !KBUILD_USE_KOBJCACHE
+ TOOL_GXX64_COMPILE_CXX_OUTPUT =
+ define TOOL_GXX64_COMPILE_CXX_CMDS
+ 	$(QUIET)$(TOOL_GXX64_CXX) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+@@ -207,7 +207,7 @@ TOOL_GXX64_COMPILE_AS_DEPEND =
+ TOOL_GXX64_COMPILE_AS_DEPORD =
+ define TOOL_GXX64_COMPILE_AS_CMDS
+ 	$(QUIET)$(TOOL_GXX64_AS) -c\
+-		$(flags) $(addprefix -I, $(incs)) $(addprefix -D, $(defs))\
++		$(flags) $(addprefix -I, $(incs)) -I${includedir} $(addprefix -D, $(defs))\
+ 		-Wp,-MD,$(dep) -Wp,-MT,$(obj) -Wp,-MP\
+ 		-o $(obj)\
+ 		$(abspath $(source))
+-- 
+1.9.1
+

--- a/meta-ostro/recipes-core/vboxmanage/files/remove-x11.patch
+++ b/meta-ostro/recipes-core/vboxmanage/files/remove-x11.patch
@@ -1,0 +1,49 @@
+Virtualbox: Remove X11 dependencies
+
+Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>
+---
+ src/VBox/Additions/Makefile.kmk | 3 ---
+ src/VBox/GuestHost/Makefile.kmk | 9 ---------
+ 2 files changed, 12 deletions(-)
+
+diff --git a/src/VBox/Additions/Makefile.kmk b/src/VBox/Additions/Makefile.kmk
+index 3e45e65..ab08ab0 100644
+--- a/src/VBox/Additions/Makefile.kmk
++++ b/src/VBox/Additions/Makefile.kmk
+@@ -48,9 +48,6 @@ VBOX_WITH_ADDITIONS_ISO.$(KBUILD_TARGET).$(KBUILD_TARGET_ARCH) = 1
+ include $(PATH_SUB_CURRENT)/common/Makefile.kmk
+
+ ifndef VBOX_ONLY_VALIDATIONKIT
+- ifdef VBOX_WITH_X11_ADDITIONS
+-  include $(PATH_SUB_CURRENT)/x11/Makefile.kmk
+- endif
+
+  ifeq ($(KBUILD_TARGET),freebsd)
+   include $(PATH_SUB_CURRENT)/freebsd/Makefile.kmk
+diff --git a/src/VBox/GuestHost/Makefile.kmk b/src/VBox/GuestHost/Makefile.kmk
+index 8fb8a48..bb1c07e 100644
+--- a/src/VBox/GuestHost/Makefile.kmk
++++ b/src/VBox/GuestHost/Makefile.kmk
+@@ -18,19 +18,10 @@
+ SUB_DEPTH = ../../..
+ include $(KBUILD_PATH)/subheader.kmk
+
+-# Include sub-makefile(s).
+-ifdef VBOX_WITH_CROGL
+- include $(PATH_SUB_CURRENT)/OpenGL/Makefile.kmk
+-endif
+-
+ ifdef VBOX_WITH_HGSMI
+  include $(PATH_SUB_CURRENT)/HGSMI/Makefile.kmk
+ endif
+
+-ifdef VBOX_WITH_HGCM
+- include $(PATH_SUB_CURRENT)/SharedClipboard/Makefile.kmk
+-endif
+-
+ ifdef VBOX_WITH_DRAG_AND_DROP
+  include $(PATH_SUB_CURRENT)/DragAndDrop/Makefile.kmk
+ endif
+--
+1.9.1
+

--- a/meta-ostro/recipes-core/vboxmanage/files/xpidl-build-fixes.patch
+++ b/meta-ostro/recipes-core/vboxmanage/files/xpidl-build-fixes.patch
@@ -1,0 +1,27 @@
+Makefile.kmk: Modify makefile so it builds with yocto
+
+Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>
+---
+ VirtualBox-5.0.16/src/libs/xpcom18a4/Makefile.kmk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/libs/xpcom18a4/Makefile.kmk b/src/libs/xpcom18a4/Makefile.kmk
+index a560b1a..e1a8a58 100644
+--- a/src/libs/xpcom18a4/Makefile.kmk
++++ b/src/libs/xpcom18a4/Makefile.kmk
+@@ -470,10 +470,10 @@ else
+  libIDL_config_cflags := $(shell $(VBOX_LIBIDL_CONFIG) --cflags)
+  libIDL_config_libs   := $(shell $(VBOX_LIBIDL_CONFIG) --libs)
+  xpidl_CFLAGS = \
+-	$(libIDL_config_cflags)
++	$(libIDL_config_cflags) `pkg-config glib-2.0 --cflags`
+  ifeq ($(BUILD_PLATFORM),linux)
+  xpidl_LDFLAGS = \
+-	$(filter-out -l%,$(libIDL_config_libs))
++	$(filter-out -l%,$(libIDL_config_libs)) -Wl,-rpath="${VIRTUALBOX_YOCTO_LIBDIR}"
+  else
+  xpidl_LDFLAGS = \
+ 	$(libIDL_config_libs)
+--
+2.7.0
+

--- a/meta-ostro/recipes-core/vboxmanage/vboxmanage-native_5.0.16.bb
+++ b/meta-ostro/recipes-core/vboxmanage/vboxmanage-native_5.0.16.bb
@@ -1,0 +1,88 @@
+LICENSE="GPLv2"
+LIC_FILES_CHKSUM="file://COPYING;md5=e197d5641bb35b29d46ca8c4bf7f2660"
+
+inherit native
+
+BPN="VirtualBox"
+
+DEPENDS=" \
+    libxml2-native glib-2.0-native libidl-native acpica-native cdrtools-native \
+    libpng-native zlib-native openssl-native curl-native libcap-native \
+    makeself-native libpam-native libxslt-native \
+"
+
+SRC_URI=" \
+    http://download.virtualbox.org/virtualbox/${PV}/VirtualBox-${PV}.tar.bz2 \
+    file://configure.patch \
+    file://xpidl-build-fixes.patch \
+    file://include-dir.patch \
+    file://remove-x11.patch \
+    file://fix-linker-flags.patch \
+    file://disable-guest-additions.patch \
+"
+
+SRC_URI[md5sum] = "1752a485b1cb377cee5f196918cda741"
+SRC_URI[sha256sum] = "f5a44d33a1db911f445b2eb2d22d9293a96a535cba488b5a235577ef868fa63c"
+
+# export path to native libdir, as this is needed during build
+# (see xpidl build fix patch)
+export VIRTUALBOX_YOCTO_LIBDIR="${STAGING_LIBDIR_NATIVE}"
+
+# The build files seem to override LDFLAGS, so re-export it with different name and patch files to use it
+export VIRTUALBOX_YOCTO_LDFLAGS="${LDFLAGS}"
+
+# Disable everything we do not need (which turns out to be almost everything)
+VBOX_CONF = " \
+    --disable-hardening \
+    --disable-python \
+    --disable-java \
+    --disable-vmmraw \
+    --disable-sdl-ttf \
+    --disable-alsa \
+    --disable-pulse \
+    --disable-dbus \
+    --disable-kmods \
+    --disable-opengl \
+    --disable-extpack \
+    --disable-docs \
+    --disable-libvpx \
+    --disable-udptunnel \
+    --disable-devmapper \
+    --disable-vmmraw \
+    --build-headless \
+    --with-makeself='${STAGING_BINDIR_NATIVE}/makeself.sh' \
+    "
+
+# As we do not use either autotools or cmake, we have to call configure manually
+do_configure() {
+    ./configure ${VBOX_CONF}
+}
+
+do_compile() {
+    . ./env.sh
+    kmk
+}
+
+do_install() {
+    # minimal set of files for VBoxManage
+    ARCH_DIR=`ls ${B}/out`
+
+    install -d ${D}${libdir}/vboxmanage
+    install -m 0755 ${B}/out/${ARCH_DIR}/release/bin/VBoxManage ${D}${libdir}/vboxmanage
+    install -m 0644 ${B}/out/${ARCH_DIR}/release/bin/VBoxDDU.so ${D}${libdir}/vboxmanage
+    install -m 0644 ${B}/out/${ARCH_DIR}/release/bin/VBoxRT.so ${D}${libdir}/vboxmanage
+    install -m 0644 ${B}/out/${ARCH_DIR}/release/bin/VBoxXPCOM.so ${D}${libdir}/vboxmanage
+    install -m 0755 ${B}/out/${ARCH_DIR}/release/bin/VBoxSVC ${D}${libdir}/vboxmanage
+    install -m 0755 ${B}/out/${ARCH_DIR}/release/bin/VBoxXPCOMIPCD ${D}${libdir}/vboxmanage
+
+    install -d ${D}${libdir}/vboxmanage/components
+    install -m 0644 ${B}/out/${ARCH_DIR}/release/bin/components/VBoxC.so ${D}${libdir}/vboxmanage/components
+    install -m 0644 ${B}/out/${ARCH_DIR}/release/bin/components/VBoxSVCM.so ${D}${libdir}/vboxmanage/components
+    install -m 0644 ${B}/out/${ARCH_DIR}/release/bin/components/VBoxXPCOMBase.xpt ${D}${libdir}/vboxmanage/components
+    install -m 0644 ${B}/out/${ARCH_DIR}/release/bin/components/VBoxXPCOMIPCC.so ${D}${libdir}/vboxmanage/components
+    install -m 0644 ${B}/out/${ARCH_DIR}/release/bin/components/VirtualBox_XPCOM.xpt ${D}${libdir}/vboxmanage/components
+
+
+    install -d ${D}${bindir}
+    ln -sf ../lib/vboxmanage/VBoxManage ${D}${bindir}/VBoxManage
+}


### PR DESCRIPTION
Add virtualbox recipe and virtualbox appliance generation as additional image type. Virtualbox appliances are currently generated for intel-corei7-64 and intel-quark images.

This is, at this stage, primarily meant to trigger CI testing and gather feedback. In no particular order:

* Recipes for virtualbox and libidl (which is dependency for virtualbox) are currently placed under meta-ostro/recipes-core. I'm not sure if this is the correct place.
* The shell function that handles the appliance generation is in image-dsk.bbclass. I'm not sure if this is proper place for this either.
* There was discussion on mailing list, that using intel-quark as the 32-bit variant is likely a bad idea, as it is highly machine dependent. Perhaps machine independent 32 bit image should be used instead (intel-corei7-32?)
* libidl recipe was originally in meta-layer, but was removed at some point. Brief googling did not reveal if it was completely removed, or moved to some other layer. The recipe is from here: http://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/packages/libidl/libidl_0.8.12.bb?id=8917b6eb2999f8a894c4864246ed34ef56ff00b9
 
Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>
