### PR TITLE
soletta-dev-app: disable by default.

### DIFF
--- a/meta-ostro/recipes-soletta/dev-app/soletta-dev-app_%.bbappend
+++ b/meta-ostro/recipes-soletta/dev-app/soletta-dev-app_%.bbappend
@@ -1,0 +1,5 @@
+# Do not start the systemd-dev-app services by default. To enable them, log in
+# to the system and enable soletta-dev-app-server.service and
+# soletta-dev-app-avahi-discover.service.
+
+SYSTEMD_AUTO_ENABLE_${PN} = "disable"


### PR DESCRIPTION
Soletta-dev-app provides a powerful development environment allowing for complete system control. Do not enable it during system boot to make development images more secure out-of-box.

This requires solettaproject/meta-soletta#52 to be merged in Ostro OS.