### PR TITLE
ostro.conf: disable running fsck at boot time

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -307,3 +307,8 @@ INPUTANALYZER_WHITELIST = '/(meta|meta-yocto-bsp|meta-intel|meta-java|meta-oic|m
 # re-use uninative shim released by Yocto Project / OE
 require conf/distro/include/yocto-uninative.inc
 INHERIT += "uninative"
+
+# Disable running fsck at boot. System clock is typically wrong at early boot
+# stage due to lack of RTC backup battery. This causes unnecessary fixes being
+# made due to filesystem metadata time stamps being in future.
+APPEND_append = " fsck.mode=skip"


### PR DESCRIPTION
Disable running fsck at boot. System clock is typically wrong at early
boot stage due to lack of RTC backup battery. This causes unnecessary
fixes being made due to filesystem metadata time stamps being in future.

Ostro images use journaling filesystem and thus running fsck at boot is
not necessary

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>