### PR TITLE
DOC: update building-images

### DIFF
--- a/doc/howtos/building-images.rst
+++ b/doc/howtos/building-images.rst
@@ -12,40 +12,68 @@ Project tools, as explained in the `Yocto Project Quick Start Guide`_.
 Initial Steps
 =============
 
-1. Check out the ``ostro-os`` repository from the ``ostroproject`` GitHub area.  This will retrieve the Ostro OS source code
-   and necessary Yocto Project tools and configuration files. The Ostro OS code is a combination of
-   several different components in a single repository.  (See the README in the cloned copy you just made 
-   for up-to-date details on what’s included.)
-2. In the repository, run :command:`source oe-init-build-env` to setup the Yocto Project build environment.
-3. Update the :file:`conf/local.conf` configuration file (more details about this in the sections below)
-4. Generate an Ostro OS image using :command:`bitbake ostro-image` (additional build target options are explained
-   in the sections below.)
-5. Install and boot as described in the :ref:`booting-and-installation` tech note.
+#. If your development system is behind a firewall, verify that your proxy settings are configured 
+   to allow access to    the internet for http, https, ftp, and git resources needed by 
+   the Yocto Project build tools, as  explained in `Yocto Project Quick Start: Building Images`_ 
+   and with more details in `Yocto Project: Working Behind a Network Proxy`_
 
-Depending on your development machine’s performance, building an image from source 
-(the :command:`bitbake ostro-image` command) may take a few hours to complete the first time. 
-It will download and compile all 
-the source code needed to create the binary image, including the Linux kernel, 
-compiler tools, upstream components and Ostro OS-specific patches.  (If you haven't 
-done so yet, this might be a good time to read through 
-the `Yocto Project Quick Start Guide`_.)
+#. Check out the ``ostro-os`` repository from the ``ostroproject`` GitHub area.  ::
 
-When the build process completes, the generated image will be in the folder 
-:file:`build/tmp-glibc/deploy/images/$(MACHINE)`
-       
-If errors occur during the build, refer to the `Yocto Project Errors and Warnings`_ documentation to help 
-resolve the issues and repeat the :command:`bitbake ostro-image` command to continue.
+   $ git clone https://github.com/ostroproject/ostro-os.git
+
+   This clone command will retrieve the Ostro OS recipes
+   and necessary Yocto Project tools and configuration files.  This ``ostro-os`` repository is a 
+   combination of several different components gathered into a single repository. See the README 
+   in the cloned copy you just made for up-to-date details on what’s included.)
+#. In the repository folder you just cloned, setup the Yocto Project build environment. ::
+
+   $ cd ostro-os
+   $ source oe-init-build-env
+
+   This will leave you in the ``ostro-os/build`` folder.
+
+#. Edit the :file:`conf/local.conf` configuration text file and verify general configuration information is
+   how you want it (more details about this in the sections below)
+
+#. Be sure you're still in the ``ostro-os/build`` folder, and then generate an Ostro OS development 
+   image using :command:`bitbake`. (additional build target options are explained
+   in the sections below.) ::
+
+   $ bitbake ostro-image-dev
+
+   Depending on the number of processors and cores, the amount of RAM, the speed of the internet connection and
+   other factors, the build process could take several hours the first time you run it. 
+   It will download and compile all the source code needed to create the binary image, including the Linux kernel, 
+   compiler tools, upstream components and Ostro OS-specific patches.  (If you haven't 
+   done so yet, this might be a good time to read through 
+   the `Yocto Project Quick Start Guide`_.) Subsequent builds
+   run much faster since parts of the build are cached. 
+          
+   If errors occur during the build, refer to the `Yocto Project Errors and Warnings`_ documentation to help 
+   resolve the issues, and repeat the ``bitbake ostro-image-dev`` command to continue.
+   
+   When the build process completes, the generated image will be in the folder 
+   :file:`build/tmp-glibc/deploy/images/$(MACHINE)`
+
+#. Copy this image to bootable media (such as a USB thumb drive or microSD card), and 
+   boot the image you just generated on your target hardware, 
+   as described in the :ref:`booting-and-installation` tech note.
 
 .. _`Yocto Project Errors and Warnings`: http://www.yoctoproject.org/docs/current/mega-manual/mega-manual.html#ref-qa-checks
+.. _`Yocto Project Quick Start: Building Images`: http://www.yoctoproject.org/docs/current/yocto-project-qs/yocto-project-qs.html#qs-building-images
+.. _`Yocto Project: Working Behind a Network Proxy`: https://wiki.yoctoproject.org/wiki/Working_Behind_a_Network_Proxy
+
 
 Image Configuration
 ===================
 
 Building images depends on choosing the private keys that are needed
-during the build process. One either has to generate and configure
-these keys or disable the features which depend on them.
+during the build process: you either generate and configure
+these keys, or disable the features which depend on them. In some cases,
+common configuration options are included but commented out and can
+be enabled by removing the comment.
 
-In addition, images are locked down by default: for example, none of
+Images are locked down by default: for example, none of
 the existing user accounts (including root) has a password set, so
 logging into the running system is impossible. Before building an image,
 you must choose a way of interacting with the system after it has booted.
@@ -54,7 +82,8 @@ you must choose a way of interacting with the system after it has booted.
 Target MACHINE Architecture
 ----------------------------
 
-The build's default target architecture ``MACHINE`` is ``intel-corei7-64``, 
+The build's default target architecture ``MACHINE`` is ``intel-corei7-64``, appropriate for the
+MinnowBoard Turbot and GigaByte platforms, 
 as configured in :file:`build/conf/local.conf`. 
 You can edit the :file:`local.conf` file to change this to a different machine appropriate for your platform. 
 
@@ -72,17 +101,18 @@ For currently :ref:`platforms`, the appropriate ``MACHINE`` selections are:
     BeagleBone Black            beaglebone
     ==========================  ====================================
 
-Virtual machine images (a :file:`.vdi` file) are created for each of these builds hardware platforms as part 
-of the build process (and included in the prebuilt image folders too).
+Virtual machine images (a :file:`.vdi` file) are created for the ``intel-corei7-64``  hardware platforms as part 
+of the build process (and included in the prebuilt image folder too).
 
 Base Images
 -----------
 
-``ostro-image.bb`` is the image recipe used by the Ostro
-project. It uses image features (configured via ``IMAGE_FEATURES``) to
+In your cloned ``ostro-os`` repository folder, ``./meta-ostro/recipes-image/images/ostro-image.bb`` is the 
+image recipe used for the Ostro
+project. This recipe file uses image features (configured via ``IMAGE_FEATURES``) to
 control the content and the image configuration.
 
-Internally, several virtual image variants are created from that base
+Internally, several image variants can be created from that base
 recipe. They differ in the set of image features added or removed
 from the base recipe:
 
@@ -91,10 +121,6 @@ ostro-image:
 
 ostro-image-dev:
     The same as ostro-image, plus build and debugging tools.
-
-ostro-image-minimal:
-    A smaller image which still has the core OS, but none of the
-    optional runtimes.
 
 Additional image variants can be defined in the ``local.conf``. For
 example, the following adds ``ostro-image-noima`` and
@@ -107,22 +133,22 @@ no IMA keys are needed::
 Image Formats for EFI platforms
 -------------------------------
 
-Note: The following chapter is applicable only to EFI platforms.
-
-It is possible to produce different types of images:
+For EFI platforms, you can produce different types of images:
 
 .dsk:
-    The basic format, which can be written to a block device with "dd".
+    The basic format, written to a block device to create a bootable image.
 
 .dsk.vdi:
-    VirtualBox format, for running OSTRO inside a Virtual Machine.
+    VirtualBox* format, for running Ostro OS inside a Virtual Machine.
 
 compressed formats:
     Same as above, only compressed, to reduce (final) space occupation
     and speed up the transfer between systems of the Ostro OS image.
     Notice that the creation of compressed images will require additional
     temporary space, because the creation of the compressed image depends
-    on the presence of the uncompressed one.
+    on the presence of the uncompressed one.  (To save download time and
+    server disk space, we only provide compressed images
+    from http://download.ostroproject.org.)
 
     All compression methods listed for ``COMPRESSIONTYPES`` in
     ``meta/classes/image_types.bbclass`` are supported. In addition,
@@ -149,10 +175,10 @@ will create both the raw and the VirtualBox images, both compressed.
 Development Images
 ------------------
 
-All images provided by the Ostro Project are targetting
-developers. Because the project wants to avoid having developers
+All images provided by the Ostro Project are intended for
+developers and not directly for production use. To avoid having developers
 accidentally build images for real products that have development
-features enabled, explicit changes in ``local.conf`` are needed to
+features enabled, you must make explicit changes in ``local.conf`` to
 enable them.
 
 Developers building their own images for personal use can follow these
@@ -219,14 +245,14 @@ only that one), here is how you can proceed::
 
     OSTRO_IMAGE_EXTRA_INSTALL_append_pn-ostro-image-dev = " strace"
 
-Beware of the leading space, it is needed when using ``_append``.
+Be careful to use a leading space when specifying additional packages with ``_append``.
 
 This example assumes that :command:`bitbake ostro-image-dev` is used to build
 an image. By making the append conditional on the name of the image,
 different images can be built with different content inside the same
 build configuration.
 
-Alternatively, ``CORE_IMAGE_EXTRA_INSTALL`` can also be used. The
+Alternatively, ``CORE_IMAGE_EXTRA_INSTALL`` can also be used, though not recommended. The
 difference is that this will also affect the initramfs images, which is
 often not intended.
 
@@ -235,6 +261,6 @@ Removing Previous Image to Save Disk Space
 
 Every image built gets copied into the deploy directory. As you're developing,
 these repeated builds will start accumulating and use up more and more
-disk space. You can save disk space by removing previous images before the
-new one is built by adding (or uncommenting) this line in your
+disk space. You can save disk space by removing previous images after the
+new one is successfully built by adding (or uncommenting) this line in your
 :file:`local.conf`: ``RM_OLD_IMAGE = "1"``


### PR DESCRIPTION
Update doc for building images with more clarity for how to clone sources and build
an image and (trying to) bringing doc up to date with build #411 details.  Might need
to re-address build targets as final changes are made.

[skip ci]

Signed-off-by: David Kinder <david.b.kinder@intel.com>