### PR TITLE
local.conf.sample: enable SSTATE_MIRRORS by default

### DIFF
--- a/doc/howtos/building-images.rst
+++ b/doc/howtos/building-images.rst
@@ -174,8 +174,8 @@ parts do not need to be rebuilt. The Yocto Project shared state code supports
 incremental builds and attempts to accelerate build time through the use
 of prebuilt data cache objects configured with the ``SSTATE_MIRRORS`` setting.
 
-By default, this ``SSTATE_MIRRORS`` configuration is disabled in :file:`conf/local.conf`
-but can be easily enabled by uncommenting the ``SSTATE_MIRRORS`` line
+By default, this ``SSTATE_MIRRORS`` configuration is enabled in :file:`conf/local.conf`
+but can be disabled (if desired) by commenting the ``SSTATE_MIRRORS`` line
 in your :file:`conf/local.conf` file, as shown here:::
 
    # Example for Ostro OS setup, recommended to use it:

--- a/meta-ostro/conf/local.conf.sample
+++ b/meta-ostro/conf/local.conf.sample
@@ -243,8 +243,9 @@ BB_DISKMON_DIRS = "\
 #file://.* http://someserver.tld/share/sstate/PATH;downloadfilename=PATH \n \
 #file://.* file:///some/local/dir/sstate/PATH"
 #
-# Example for Ostro OS setup, recommended to use it:
-#SSTATE_MIRRORS ?= "file://.* http://download.ostroproject.org/sstate/ostro-os/PATH"
+# Ostro OS recomended way is to use SSTATE cache produced by Ostro Project CI
+# during official builds:
+SSTATE_MIRRORS ?= "file://.* http://download.ostroproject.org/sstate/ostro-os/PATH"
 
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
 # track the version of this file when it was generated. This can safely be ignored if


### PR DESCRIPTION
Ostro Project CI produces uninative SSTATE cache which is
beneficial for most of users to speed-up builds.
Enable it by default in local.conf

Signed-off-by: Alexander Kanevskiy <kad@linux.intel.com>