### PR TITLE
ostro-image.bb: avoid task hash mismatch

### DIFF
--- a/meta-ostro/recipes-image/images/ostro-image.bb
+++ b/meta-ostro/recipes-image/images/ostro-image.bb
@@ -207,6 +207,8 @@ IMAGE_CLASSES += "${@bb.utils.contains_any('MACHINE', 'intel-core2-32 intel-core
 inherit core-image extrausers image-buildinfo
 
 BUILD_ID ?= "${DATETIME}"
+# Do not re-trigger builds just because ${DATETIME} changed.
+BUILD_ID[vardepsexclude] += "DATETIME"
 IMAGE_BUILDINFO_VARS_append = " BUILD_ID"
 
 IMAGE_NAME = "${IMAGE_BASENAME}-${MACHINE}-${BUILD_ID}"


### PR DESCRIPTION
A recent change in bitbake now triggers "Taskhash mismatch" errors for
do_rootfs when building Ostro images locally. CI builds are not affected
because BUILD_ID is set differently.

Ignoring the BUILD_ID -> DATETIME dependency looks like the right
solution, because conceptually we want the new value to be used when
it gets used, but we do not want a change in it to trigger a rebuild.

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>