### PR TITLE
ostroproject-ci: enabler for flexible automatic testing

### DIFF
--- a/meta-ostro/conf/distro/include/ostroproject-ci.inc
+++ b/meta-ostro/conf/distro/include/ostroproject-ci.inc
@@ -52,6 +52,11 @@ OSTROPROJECT_CI_SDK_TARGETS=""
 OSTROPROJECT_CI_ESDK_TARGETS="${DISTRO}-image"
 # Following targets would be executed with do_test_iot_export task
 OSTROPROJECT_CI_TEST_EXPORT_TARGETS="${DISTRO}-image"
+# Execute automatic tests for following images with corresponding
+# test suite and test files.
+# Space separated list of tuples, each should in format:
+# <image_name>,<testsuite_name>,<testfiles_name>,$MACHINE
+OSTROPROJECT_CI_TEST_RUNS="${DISTRO}-image,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE}"
 
 #
 # Dymamic section.


### PR DESCRIPTION
New variable OSTROPROJECT_CI_TEST_RUNS allows
to configure which images and with which test suite
and test data would be tested after CI build completed.
Format is space separated list of tuples.
Each tuple is comma separated list of items:
- image name to test
- test suite archive for that image
- test data archive for testsuite
- MACHINE build target

Variable can be overriden for each individual MACHINE

Signed-off-by: Alexander Kanevskiy <kad@linux.intel.com>