### PR TITLE
soletta-dev-app: fix dangling symlinks in rootfs

### DIFF
--- a/meta-ostro/recipes-soletta/dev-app/soletta-dev-app_%.bbappend
+++ b/meta-ostro/recipes-soletta/dev-app/soletta-dev-app_%.bbappend
@@ -9,3 +9,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += " file://0001-Add-firewall-rules-to-allow-access.patch"
 
 RDEPENDS_${PN} += " iptables"
+
+do_install_prepend() {
+    rm -rf ${S}/patches
+}


### PR DESCRIPTION
dev-app's do_install copies everything from ${S}, including
patches/ directory that is created by bitbake.

patches/ includes symlinks to patches applied from SRC_URI. These
symlinks point to destinations that do not get included in
do_install.

ostro-sanity.bbclass checks for dangling symlinks in rootfs as to
ensure swupd-enabled images work correctly.

To fix the QA errors, remove patches/ before copying everything
from ${S}.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>