### PR TITLE
building-images.rst: move SSTATE_MIRRORS paragraph towards the end

### DIFF
--- a/doc/howtos/building-images.rst
+++ b/doc/howtos/building-images.rst
@@ -191,26 +191,6 @@ with ``# require conf/distro/include/ostro-os-development.inc`` and
 uncomment it.
 
 
-Accelerating Build Time Using Shared-State Files Cache
-------------------------------------------------------
-
-As explained in the `Yocto Project Shared State Cache documentation`_, by design
-the build system builds everything from scratch unless it can determine that
-parts do not need to be rebuilt. The Yocto Project shared state code supports
-incremental builds and attempts to accelerate build time through the use
-of prebuilt data cache objects configured with the ``SSTATE_MIRRORS`` setting.
-
-By default, this ``SSTATE_MIRRORS`` configuration is enabled in :file:`conf/local.conf`
-but can be disabled (if desired) by commenting the ``SSTATE_MIRRORS`` line
-in your :file:`conf/local.conf` file, as shown here:::
-
-   # Example for Ostro OS setup, recommended to use it:
-   #SSTATE_MIRRORS ?= "file://.* http://download.ostroproject.org/sstate/ostro-os/PATH"
-
- 
-
-.. _Yocto Project Shared State Cache documentation: http://www.yoctoproject.org/docs/2.0/mega-manual/mega-manual.html#shared-state-cache
-
 Production Images
 -----------------
 
@@ -255,6 +235,27 @@ build configuration.
 Alternatively, ``CORE_IMAGE_EXTRA_INSTALL`` can also be used, though not recommended. The
 difference is that this will also affect the initramfs images, which is
 often not intended.
+
+
+Accelerating Build Time Using Shared-State Files Cache
+------------------------------------------------------
+
+As explained in the `Yocto Project Shared State Cache documentation`_, by design
+the build system builds everything from scratch unless it can determine that
+parts do not need to be rebuilt. The Yocto Project shared state code supports
+incremental builds and attempts to accelerate build time through the use
+of prebuilt data cache objects configured with the ``SSTATE_MIRRORS`` setting.
+
+By default, this ``SSTATE_MIRRORS`` configuration is enabled in :file:`conf/local.conf`
+but can be disabled (if desired) by commenting the ``SSTATE_MIRRORS`` line
+in your :file:`conf/local.conf` file, as shown here:::
+
+   # Example for Ostro OS setup, recommended to use it:
+   #SSTATE_MIRRORS ?= "file://.* http://download.ostroproject.org/sstate/ostro-os/PATH"
+
+
+.. _Yocto Project Shared State Cache documentation: http://www.yoctoproject.org/docs/2.0/mega-manual/mega-manual.html#shared-state-cache
+
 
 Removing Previous Image to Save Disk Space
 ------------------------------------------


### PR DESCRIPTION
This commit moves the paragraph explaining how SSTATE_MIRRORS can
be used in Ostro towards the end of the document. It keeps the
'Development Images' and 'Production Images' sections together
which makes for a more natural flow when reading through the doc

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>