### PR TITLE
doc: cover changes related to swupd image reorganization

### DIFF
--- a/doc/architecture/system-and-security-architecture.rst
+++ b/doc/architecture/system-and-security-architecture.rst
@@ -433,11 +433,8 @@ perfectly secure! Do not use them in products built for end-customers and
 use them only in secure environments.
 
 
-The Ostro Project provides two different pre-compiled images,
-``ostro-image`` and ``ostro-image-dev``. Despite the name, currently *both*
-are compiled as development images. The only difference is that
-``ostro-image-dev`` already includes development (``gcc``) and debugging
-tools (``strace``, ``valgrind``, etc.). There are no pre-compiled
+The Ostro Project provides different pre-compiled images. All of them
+are compiled as development images. Currently there are no pre-compiled
 production images.
 
 The following table summarizes the differences between the default

--- a/doc/howtos/booting-and-installation.rst
+++ b/doc/howtos/booting-and-installation.rst
@@ -21,10 +21,10 @@ Two images are of interest for this process (depending if you're using real hard
 Ostro OS Images
 ===============
 
-As explained in the :ref:`Building Images` tech note, there are several image variants available
-depending on your need.  For simplicity and the needs of this tech note, we'll use the dev image that includes
-additional build and debugging tools that wouldn't typically be included in a production device image. This
-dev image also will auto-login as ``root`` at the console, something that normally would not be available
+As explained in the :ref:`Building Images` tech note, there are several image configurations available
+depending on your need.  For simplicity and the needs of this tech note, we'll use the reference image that includes
+additional configuration changes that wouldn't typically be included in a production device image. This
+reference image will auto-login as ``root`` at the console, something that normally would not be available
 in a production device image but is quite useful during development.
 
 
@@ -190,7 +190,7 @@ Flashing an Intel Edison requires use of a breakout board and two micro-USB cabl
    for recovery cases.)
 #. Plug in a micro-USB cable to the J3 connector on the board (corner next to the FTDI chip).
 #. Flip the DIP switch towards jumper J16.
-#. Download the ``ostro-image`` or ``ostro-image-dev`` image from the Ostro OS download folder for
+#. Download the ``ostro-image-swupd-reference`` image from the Ostro OS download folder for
    Edison (on https://download.ostroproject.org/releases/ostro-os/milestone/).
 #. Extract the image from the archive using the command::
 
@@ -237,7 +237,7 @@ In our setup steps below, we're using an 8GB microSD card in an SD adapter that'
    Download these four files to your host computer::
 
       MLO
-      ostro-image-dev-beaglebone-*.rootfs.tar.bz2
+      ostro-image-swupd-reference-beaglebone-*.rootfs.tar.bz2
       u-boot.img
       zImage-am335x-boneblack.dtb
 
@@ -306,7 +306,7 @@ In our setup steps below, we're using an 8GB microSD card in an SD adapter that'
 
      $ mkdir rootfs
      $ sudo mount /dev/mmcblk0p2 rootfs
-     $ sudo tar xvjf ostro-image-dev-beaglebone*.rootfs.tar.bz2 --wildcards --xattrs --xattrs-include=*  -C rootfs
+     $ sudo tar xvjf ostro-image-swupd-reference-beaglebone*.rootfs.tar.bz2 --wildcards --xattrs --xattrs-include=*  -C rootfs
 
 #.  Before unmounting the device, we also need to add the device tree blob file (``zImage-am335x-boneblack.dtb``)
     that you downloaded (or from your own build).
@@ -369,7 +369,7 @@ own build from source.  As with the other examples above, we recommend you start
    While still on the system configuration, click on the "Acceleration" tab and verify that
    "Enable VT-x/AMX-V" (HW virtualization support) is checked. Click OK.
 #. Finally, click on the "Start" arrow button and your new virtual machine will start
-   booting the Ostro OS Dev image and auto-login as root, no password is required.
+   booting the Ostro OS reference image and auto-login as root, no password is required.
 
 If booting fails with a kernel panic, verify you’re using VirtualBox version 5.0.2 or later.  You can shut the machine down
 by either using the :command:`shutdown now` within the running Ostro OS image, or by using the VirtualBox menu

--- a/doc/howtos/building-images.rst
+++ b/doc/howtos/building-images.rst
@@ -211,16 +211,15 @@ The ``ostro-image.bbclass`` can be used in two modes, depending on the ``swupd``
 
 Developers are encouraged to start building images the traditional way
 by using image recipes like ``ostro-image-noswupd`` where swupd is
-turned off, because:
+turned off and only use swupd during deployment.
 
-a) swupd support is still new and may have unexpected problems.
-b) image and swupd bundle creation cause additional overhead (disk
-   space, compile time) due to the extra work that needs to be done
-   (creating multiple rootfs directories to simulate what needs to be
-   in each bundle, preparing the data that the swupd client pulls via
-   HTTP(S) when checking for updates). This can increase the build
-   time from several minutes to over an hour or more (depending on the
-   number of bundles and files).
+That's because image creation based on swupd bundles and swupd bundle
+creation itself cause additional overhead (disk space, compile time)
+due to the extra work that needs to be done (creating multiple rootfs
+directories to simulate what needs to be in each bundle, preparing the
+data that the swupd client pulls via HTTP(S) when checking for
+updates). This can increase the build time from several minutes to
+over an hour or more (depending on the number of bundles and files).
 
 The following instructions assume that swupd is not used.
 

--- a/doc/howtos/building-images.rst
+++ b/doc/howtos/building-images.rst
@@ -214,8 +214,13 @@ by using image recipes like ``ostro-image-noswupd`` where swupd is
 turned off, because:
 
 a) swupd support is still new and may have unexpected problems.
-b) image and swupd bundle creation cause additional overhead
-   due to the extra work that needs to be done.
+b) image and swupd bundle creation cause additional overhead (disk
+   space, compile time) due to the extra work that needs to be done
+   (creating multiple rootfs directories to simulate what needs to be
+   in each bundle, preparing the data that the swupd client pulls via
+   HTTP(S) when checking for updates). This can increase the build
+   time from several minutes to over an hour or more (depending on the
+   number of bundles and files).
 
 The following instructions assume that swupd is not used.
 


### PR DESCRIPTION
@dkinder @gvancuts please help review. This completes the integration
of meta-swupd as far as normal developers go. Documenting the usage of
swupd and swupd-based images is intentionally left out for now. I don't
have plans to add anything further about that.

This also replaces PR #98.

[skip ci]