### PR TITLE
simplify image content and bundles

### DIFF
--- a/doc/howtos/booting-and-installation.rst
+++ b/doc/howtos/booting-and-installation.rst
@@ -190,7 +190,7 @@ Flashing an Intel Edison requires use of a breakout board and two micro-USB cabl
    for recovery cases.)
 #. Plug in a micro-USB cable to the J3 connector on the board (corner next to the FTDI chip).
 #. Flip the DIP switch towards jumper J16.
-#. Download the ``ostro-image-swupd-reference`` image from the Ostro OS download folder for
+#. Download the ``ostro-image-swupd`` image from the Ostro OS download folder for
    Edison (on https://download.ostroproject.org/releases/ostro-os/milestone/).
 #. Extract the image from the archive using the command::
 
@@ -237,7 +237,7 @@ In our setup steps below, we're using an 8GB microSD card in an SD adapter that'
    Download these four files to your host computer::
 
       MLO
-      ostro-image-swupd-reference-beaglebone-*.rootfs.tar.bz2
+      ostro-image-swupd-beaglebone-*.rootfs.tar.bz2
       u-boot.img
       zImage-am335x-boneblack.dtb
 
@@ -306,7 +306,7 @@ In our setup steps below, we're using an 8GB microSD card in an SD adapter that'
 
      $ mkdir rootfs
      $ sudo mount /dev/mmcblk0p2 rootfs
-     $ sudo tar xvjf ostro-image-swupd-reference-beaglebone*.rootfs.tar.bz2 --wildcards --xattrs --xattrs-include=*  -C rootfs
+     $ sudo tar xvjf ostro-image-swupd-beaglebone*.rootfs.tar.bz2 --wildcards --xattrs --xattrs-include=*  -C rootfs
 
 #.  Before unmounting the device, we also need to add the device tree blob file (``zImage-am335x-boneblack.dtb``)
     that you downloaded (or from your own build).

--- a/doc/howtos/building-images.rst
+++ b/doc/howtos/building-images.rst
@@ -247,14 +247,12 @@ Alternatively, ``CORE_IMAGE_EXTRA_INSTALL`` can also be used. The
 difference is that this will also affect the initramfs images, which is
 often not intended.
 
-Including ``ostro-os-development.inc`` will automatically extend the
-configuration of ``ostro-image-noswupd`` such that the content matches
-what gets published as the ``ostro-image-swupd-reference``. For
-example, an ssh server gets added. If that is not desired, uncomment
-the following lines in ``conf/local.conf``::
+The example ``ostro-image-swupd`` is defined such that its default
+content corresponds to ``ostro-image-noswupd``. It is possible to
+reconfigure it so that it matches ``ostro-image-swupd-dev``::
 
-  OSTRO_DEVELOPMENT_EXTRA_FEATURES = ""
-  OSTRO_DEVELOPMENT_EXTRA_INSTALL = ""
+    OSTRO_IMAGE_NOSWUPD_EXTRA_FEATURES_append = "${OSTRO_IMAGE_FEATURES_DEV}"
+    OSTRO_IMAGE_NOSWUPD_EXTRA_INSTALL_append = "${OSTRO_IMAGE_INSTALL_DEV}"
 
 
 Accelerating Build Time Using Shared-State Files Cache

--- a/meta-ostro/conf/conf-notes.txt
+++ b/meta-ostro/conf/conf-notes.txt
@@ -1,7 +1,8 @@
 Common targets are:
     ostro-image-noswupd (when building without swupd,
                          the recommended mode for local image building)
-    ostro-image-swupd-reference (when building with swupd)
+    ostro-image-swupd   (when building with swupd, the recommended mode
+                         for deployment)
 
 We recommend to use VirtualBox if you wish to run an Ostro image in a
 virtual environment. Please check the doc/howtos/booting-and-installation.rst

--- a/meta-ostro/conf/distro/include/ostro-os-development.inc
+++ b/meta-ostro/conf/distro/include/ostro-os-development.inc
@@ -14,14 +14,6 @@ OSTRO_EXTRA_MOTD () {
 ************************************
 }
 
-# Extend the default package selection and image configuration of the
-# no-swupd "ostro-image" to match the content of the swupd
-# "ostro-image-swupd-reference".
-OSTRO_IMAGE_NOSWUPD_EXTRA_FEATURES_append = " ${OSTRO_DEVELOPMENT_EXTRA_FEATURES}"
-OSTRO_IMAGE_NOSWUPD_EXTRA_INSTALL_append = " ${OSTRO_DEVELOPMENT_EXTRA_INSTALL}"
-OSTRO_DEVELOPMENT_EXTRA_FEATURES ?= "${OSTRO_IMAGE_FEATURES_REFERENCE}"
-OSTRO_DEVELOPMENT_EXTRA_INSTALL ?= "${OSTRO_IMAGE_INSTALL_REFERENCE}"
-
 # Everything ready, avoid initial sanity check.
 OSTRO_IMAGE_BUILD_MODE_SELECTED = "1"
 

--- a/meta-ostro/conf/distro/include/ostroproject-ci.inc
+++ b/meta-ostro/conf/distro/include/ostroproject-ci.inc
@@ -45,7 +45,7 @@ OSTRO_VM_IMAGE_TYPES = "dsk.xz dsk.zip dsk.vdi.zip dsk.bmap dsk.xz.sha256sum dsk
 # Any other symbols would be skipped in parser.
 #
 # Following targets would be used to perform default build task:
-OSTROPROJECT_CI_BUILD_TARGETS="ostro-image-noswupd ostro-image-swupd ostro-image-swupd-dev ostro-image-swupd-reference"
+OSTROPROJECT_CI_BUILD_TARGETS="ostro-image-noswupd ostro-image-swupd ostro-image-swupd-dev"
 # Following targets would be executed with do_populate_sdk task
 OSTROPROJECT_CI_SDK_TARGETS=""
 # Following targets would be executed with do_populate_sdk_ext task.

--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -35,8 +35,7 @@ SDK_INHERIT_BLACKLIST = "buildhistory icecc buildhistory-extra buildstats-summar
 # In local builds, we only have ${DATETIME} as something that
 # increments automatically, but it is too large for an integer number
 # on 32 bit systems. Therefore we substract the 2016 as the initial
-# year in which Ostro OS started using swupd (assumes a 64 build host,
-# to avoid integer overflows in Python itself) and ignore the
+# year in which Ostro OS started using swupd and ignore the
 # seconds.
 #
 # The default behavior is to not rebuild just because OS_VERSION

--- a/meta-ostro/conf/local.conf.sample
+++ b/meta-ostro/conf/local.conf.sample
@@ -272,12 +272,6 @@ CONF_VERSION = "2"
 # are not secure.
 #
 # require conf/distro/include/ostro-os-development.inc
-#
-# Including that file reconfigures "ostro-image" to have the same
-# content and configuration as the published "ostro-image-swupd-reference".
-# Uncomment these lines if that is not desired:
-# OSTRO_DEVELOPMENT_EXTRA_FEATURES = ""
-# OSTRO_DEVELOPMENT_EXTRA_INSTALL = ""
 
 # When building production images, configure IMA signing
 # as described in meta-integrity/README.md if IMA is enabled

--- a/meta-ostro/recipes-image/images/ostro-image-noswupd.bb
+++ b/meta-ostro/recipes-image/images/ostro-image-noswupd.bb
@@ -7,9 +7,18 @@ SUMMARY = "Ostro image for local builds with swupd disabled."
 # Instead extend these variables. We cannot just use OSTRO_IMAGE_EXTRA_FEATURES
 # and OSTRO_IMAGE_EXTRA_INSTALL because those affect all images based
 # on ostro-image.bbclass.
-OSTRO_IMAGE_NOSWUPD_EXTRA_FEATURES ?= ""
-OSTRO_IMAGE_NOSWUPD_EXTRA_INSTALL ?= ""
+OSTRO_IMAGE_NOSWUPD_EXTRA_FEATURES ?= "${OSTRO_IMAGE_FEATURES_REFERENCE}"
+OSTRO_IMAGE_NOSWUPD_EXTRA_INSTALL ?= "${OSTRO_IMAGE_INSTALL_REFERENCE}"
 OSTRO_IMAGE_EXTRA_FEATURES += "${OSTRO_IMAGE_NOSWUPD_EXTRA_FEATURES}"
 OSTRO_IMAGE_EXTRA_INSTALL += "${OSTRO_IMAGE_NOSWUPD_EXTRA_INSTALL}"
+
+# If the default "ostro-image-noswupd" name is
+# undesirable, write a custom image recipe similar to this one here
+# or customize the image file names.
+#
+# Example for customization in local.conf when building ostro-image-noswupd.bb:
+# IMAGE_BASENAME_pn-ostro-image-noswupd = "my-ostro-image-reference"
+# OSTRO_IMAGE_NOSWUPD_EXTRA_INSTALL_append = "my-own-package"
+# OSTRO_IMAGE_NOSWUPD_EXTRA_FEATURES_append = "dev-pkgs"
 
 inherit ostro-image

--- a/meta-ostro/recipes-image/images/ostro-image-swupd.bb
+++ b/meta-ostro/recipes-image/images/ostro-image-swupd.bb
@@ -14,12 +14,85 @@ OSTRO_IMAGE_EXTRA_INSTALL += "${OSTRO_IMAGE_SWUPD_EXTRA_INSTALL}"
 # Enable swupd.
 OSTRO_IMAGE_EXTRA_FEATURES += "swupd"
 
-# ostro-image-swupd as build target only triggers
-# the creation of swupd bundles without creating "ostro-image-swupd"
-# image files, because those would not be very useful (too minimal).
-# Instead, images can get created for the default SWUPD_IMAGES.
-OSTRO_VM_IMAGE_TYPES_pn-ostro-image-swupd = ""
-IMAGE_FSTYPES_pn-ostro-image-swupd = ""
+# Define os-core content and additional bundles. Which bundles are
+# useful depends on the use cases. For Ostro OS example images, all we
+# care about at the moment is
+# a) to demonstrate that bundles can be added and removed
+# b) build two different images (minimal and for on-target development)
+#
+# This can be achieved with just the os-core bundle (defined by the
+# content of this image recipe here) and one additional bundle
+# with the development tools and files.
+#
+# Keeping the number of bundles as low as possible is good for build
+# performance, too.
+SWUPD_BUNDLES ?= " \
+    world-dev \
+"
+
+# os-core defined via additional image features maintained in ostro-image.bbclass.
+OSTRO_IMAGE_EXTRA_FEATURES += "${OSTRO_IMAGE_FEATURES_REFERENCE}"
+OSTRO_IMAGE_EXTRA_INSTALL += "${OSTRO_IMAGE_INSTALL_REFERENCE}"
+
+# One additional bundle for on-target development.
+# Must contain all of the Ostro OS components because
+# otherwise they would not be available via swupd.
+#
+# Developers are able to tweak this bundle (for example, disabling the
+# JDK because building Java is slow) by modifying the variable in
+# their local.conf (BUNDLE_CONTENTS_WORLD_remove = "java-jdk") or
+# overridding it entirely (BUNDLE_CONTENTS_WORLD = "iotivity").
+#
+# Features already added to the os-core are listed here again
+# for the sake of simplicity. To remove them, both BUNDLE_CONTENTS_WORLD
+# and OSTRO_IMAGE_EXTRA_FEATURES need to be modified.
+#
+# We re-use OSTRO_IMAGE_PKG_FEATURES here, so Ostro OS components only
+# need to be listed once in ostro-image.bbclass. The variable expansion
+# is done so that bitbake sees the FEATURE_PACKAGES_foobar variables
+# and thus can add them to the vardeps of BUNDLE_CONTENTS_WORLD.
+BUNDLE_CONTENTS_WORLD ?= " \
+    ${@ ' '.join(['$' + chr(123) + 'FEATURE_PACKAGES_' + x + chr(125)  for x in d.getVar('OSTRO_IMAGE_PKG_FEATURES', True).split()])} \
+    ${OSTRO_IMAGE_INSTALL_DEV} \
+"
+
+BUNDLE_CONTENTS[world] = " \
+    ${BUNDLE_CONTENTS_WORLD} \
+"
+
+# When swupd bundles are enabled, choose explicitly which images
+# are created. The base image will only have the core-os bundle.
+#
+# The additional images will be called <base image recipe>-<name in SWUPD_IMAGES>,
+# for example ostro-image-swupd-dev in this case.
+#
+# Taking all this into account, we end up with the following images:
+# ostro-image-swupd -
+#    Base image plus login via getty and ssh, plus connectivity.
+#    This is what developers are expected to start with when
+#    building their first image.
+# ostro-image-swupd-dev -
+#    Image used for testing Ostro OS. Contains most of the software
+#    pre-installed, including the corresponding development files
+#    for on-target compilation.
+# ostro-image-swupd-all -
+#    Contains all defined bundles. Useful as meta target, but not
+#    guaranteed to build images successfully, for example because
+#    the content might get too large for machines with a fixed image
+#    size.
+SWUPD_IMAGES ?= " \
+    dev \
+    all \
+"
+
+# In practice the same as "all" at the moment, but conceptually different
+# and thus defined separately.
+SWUPD_IMAGES[dev] = " \
+    ${SWUPD_BUNDLES} \
+"
+SWUPD_IMAGES[all] = " \
+    ${SWUPD_BUNDLES} \
+"
 
 # Inherit the base class after changing relevant settings like
 # the image features, because the class looks at them at the time


### PR DESCRIPTION
Removes the extra "ostro-image-swupd-reference" image and the
"reference" bundle and instead moves the content into the base images
of both ostro-image-swupd and ostro-image-noswupd.

Because the doc changes would conflict with the changes in PR #100,
this PR here includes all of those commits, too. That way we can
merge PR #100 and then this one, or this one directly.

@barbieri I hope this addresses your review feedback from PR #95.

@olev @mikko @kad I expect this to speed up the builds a bit.