### PR TITLE
ostro-os-production.inc: disable consoles/getty and mute logging

### DIFF
--- a/meta-ostro/conf/distro/include/ostro-os-production.inc
+++ b/meta-ostro/conf/distro/include/ostro-os-production.inc
@@ -2,5 +2,8 @@
 # in local.conf. In contrast to ostro-os-development.inc, no fallback
 # is provided.
 
+# Disable consoles and make journald quiet (=disable system logging).
+OSTRO_IMAGE_EXTRA_FEATURES_append = " muted"
+
 # Everything is (hopefully) ready, avoid initial sanity check.
 OSTRO_IMAGE_BUILD_MODE_SELECTED = "1"

--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -298,6 +298,7 @@ PREFERRED_PROVIDER_virtual/javac-native = "ecj-bootstrap-native"
 # would have to be listed).
 
 INHERIT += "blacklist"
+PNBLACKLIST[systemd-serialgetty] = "Replaced by systemd's systemd-getty-generator"
 PNBLACKLIST[initramfs-live-install-testfs] = "DEPENDS on grub which is PNBLACKLISTed, not supported."
 PNBLACKLIST[initramfs-live-install] = "DEPENDS on grub which is PNBLACKLISTed, not supported."
 PNBLACKLIST[grub] = "World build fails on beaglebone."

--- a/meta-ostro/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-ostro/recipes-core/systemd/systemd_%.bbappend
@@ -1,5 +1,10 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
+# Prefer systemd way of creating getty@.service symlinks using
+# systemd-getty-generator (instead of the Yocto default
+# systemd-serialgetty that creates everything in do_install).
+PACKAGECONFIG_append = "serial-getty-generator"
+
 # This .bbappend enables systemd-boot from systemd source similar
 # to gummiboot_git.bb (in meta/) and .bbappend (in meta-ostro-fixes/).
 


### PR DESCRIPTION
This commit adds an image feature called 'muted' that can be
used disable all consoles and login services (getty).

In addition, 'muted' modifies systemd journald's log level such that
only emergency logs are logged. This essentially disables all debug
logs.

This leaves kernel printk setting unchanged. That is a BSP setting
Ostro does not need to touch.

The primary use for 'muted' is an a production image. Therefore, it
is added as a default there.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>