### PR TITLE
swupd-client: Fix setting unwanted SMACK attrs

### DIFF
--- a/meta-ostro/recipes-swupd/swupd-client/swupd-client_%.bbappend
+++ b/meta-ostro/recipes-swupd/swupd-client/swupd-client_%.bbappend
@@ -8,6 +8,7 @@ SRC_URI_append = "file://0001-Disable-boot-file-heuristics.patch \
                  "
 
 RDEPENDS_${PN}_class-target_append = "${@ ' gptfdisk' if ${OSTRO_USE_DSK_IMAGES} else '' }"
+DEPENDS_${PN}_append = " xattr-native"
 
 # Get rid of check-update entirely, otherwise we cannot enable
 # auto-activation.
@@ -35,4 +36,13 @@ do_install_append () {
 
     # Don't install and enable check-update.timer by default
     rm -f ${D}/${systemd_system_unitdir}/check-update.* ${D}/${systemd_system_unitdir}/multi-user.target.wants/check-update.*
+}
+
+pkg_postinst_${PN}_append () {
+    # Setting a label explicitly on the directory prevents it
+    # from inheriting other undesired attributes like security.SMACK64TRANSMUTE
+    # from upper folders (see xattr-images.bbclass for details).
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'smack', 'true', 'false', d)}; then
+       setfattr -n security.SMACK64 -v "_" $D/var/lib/swupd
+    fi
 }


### PR DESCRIPTION
Set `security.SMACK64` label explicitly on `/var/lib/swupd` to
avoid transmuting underlying directories which may be
directories that are installed as part of bundles.

The reason why it's needed is that first a directory installed
with `swupd bundle-add` command gets created under `/var/lib/swupd`
and then it is moved to its designated place. If `/var/lib/swupd`
has SMACK's transmute flag set then all directories created below
inherit this flag which leads to mismatched hashes.

Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>