### PR TITLE
Rename packagegroup node-runtime to nodejs-runtime

### DIFF
--- a/meta-ostro/classes/ostro-image.bbclass
+++ b/meta-ostro/classes/ostro-image.bbclass
@@ -41,7 +41,7 @@ OSTRO_IMAGE_PKG_FEATURES = " \
     devkit \
     iotivity \
     java-jdk \
-    node-runtime \
+    nodejs-runtime \
     nodejs-runtime-tools \
     python-runtime \
     qatests \
@@ -167,7 +167,7 @@ FEATURE_PACKAGES_ima = "packagegroup-ima-evm-utils"
 FEATURE_PACKAGES_iotivity = "packagegroup-iotivity"
 FEATURE_PACKAGES_devkit = "packagegroup-devkit"
 
-FEATURE_PACKAGES_node-runtime = "packagegroup-node-runtime"
+FEATURE_PACKAGES_nodejs-runtime = "packagegroup-nodejs-runtime"
 FEATURE_PACKAGES_nodejs-runtime-tools = "packagegroup-nodejs-runtime-tools"
 FEATURE_PACKAGES_python-runtime = "packagegroup-python-runtime"
 FEATURE_PACKAGES_java-jdk = "packagegroup-java-jdk"


### PR DESCRIPTION
Rename packagegroup-node-runtime to packagegroup-nodejs-runtime to
be consistent with the name of nodejs-runtime-tools packagegroup.

[1] https://github.com/ostroproject/meta-iot-web/pull/7
[2] This

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>