### PR TITLE
ostro.conf: update SDK_UPDATE_URL

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -10,11 +10,11 @@ SDK_UPDATE_URL = "${OSTRO_SDK_UPDATE_URL}"
 # devtool.conf when populate-sdk-ext is run.
 #
 # Example SDK_UPDATE_URLs are:
-# https://download.ostroproject.org/builds/ostro-os/latest/sdk-ext/<machine> OR
-# https://download.ostroproject.org/releases/ostro-os/milestone/<release>/sdk-ext/<machine>
+# https://download.ostroproject.org/builds/ostro-os/latest/sdk-data/<machine> OR
+# https://download.ostroproject.org/releases/ostro-os/milestone/<release>/sdk-data/<machine>
 #
 # The default setting can be overridded in local.conf
-OSTRO_SDK_UPDATE_URL ??= "https://download.ostroproject.org/builds/ostro-os/latest/sdk-ext/${MACHINE}"
+OSTRO_SDK_UPDATE_URL ??= "https://download.ostroproject.org/builds/ostro-os/latest/sdk-data/${MACHINE}"
 
 # Extensible SDK configuration: Ostro uses "minimal" type which minimizes the size of the downloaded
 # SDK itself and configures devtool to use SSTATE_MIRROR (defined in o sdk-extra.conf).


### PR DESCRIPTION
The extensible SDK is now published in two separate directories:
sdk/ for the installer .sh and sdk-data for the update data.

Therefore, we need to update SDK_UPDATE_URL to correctly point to
sdk-data.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>