### PR TITLE
busybox: disable klogd and syslogd

### DIFF
--- a/meta-ostro/recipes-core/busybox/busybox_%.bbappend
+++ b/meta-ostro/recipes-core/busybox/busybox_%.bbappend
@@ -1,0 +1,11 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+# ostro.cfg disables CONFIG_SYSLOGD so the corresponding packaging
+# needs to be dropped as well.
+SYSTEMD_PACKAGES = ""
+PACKAGES_remove = "${PN}-syslog"
+RRECOMMENDS_${PN}_remove = "${PN}-syslog"
+
+SRC_URI_append = "\
+    file://ostro.cfg \
+"

--- a/meta-ostro/recipes-core/busybox/files/ostro.cfg
+++ b/meta-ostro/recipes-core/busybox/files/ostro.cfg
@@ -1,0 +1,2 @@
+# CONFIG_KLOGD is not set
+# CONFIG_SYSLOGD is not set


### PR DESCRIPTION
The default busybox configuration builds klogd and syslogd. These
daemons also get started on the target.

Ostro uses systemd journal that captures the same logs so klogd
and syslogd are rendundant.

Drop the redundant daemons by adjusting the busybox configuration.

Fixes: https://github.com/ostroproject/ostro-os/issues/31

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>