### PR TITLE
ostro-image.bbclass: prefer shadow (motd, passwd, /dev/tty)

### DIFF
--- a/meta-ostro/classes/ostro-image.bbclass
+++ b/meta-ostro/classes/ostro-image.bbclass
@@ -135,6 +135,20 @@ export ALTERNATIVE_PRIORITY_UTIL_LINUX ?= "305"
 # just mount/umount as overrides for Toybox/Busybox.
 IMAGE_INSTALL += "util-linux"
 
+# We need "login" and "passwd" from shadow because:
+# - Busybox "login" does not use PAM and thus would require
+#   separate patching to support stateless motd (patched
+#   in libpam); also the login via getty is different compared
+#   to logins via ssh, which is potentially confusing and thus
+#   should better be avoided (either no PAM, or PAM everywhere).
+# - /dev/tty does not point to the serial console when logging
+#   in via getty and using Busybox login, so anything that
+#   tries to interact with the user (passwd, ssh) fails.
+# - shadow "passwd" creates /etc/shadow if it does not exist
+#   yet (required when setting the root password).
+export ALTERNATIVE_PRIORITY_SHADOW ?= "305"
+IMAGE_INSTALL += "shadow"
+
 # Additional features and packages used in the base images of
 # ostro-image-swupd.bb and ostro-image-noswupd.bb.
 OSTRO_IMAGE_FEATURES_REFERENCE ?= " \


### PR DESCRIPTION
Busybox login has various shortcomings compared to login from shadow,
which is what OE-core uses. Switching to Busybox was a side effect of
update-alternative re-ordering for swupd images and can be undone by
raising the shadow priority, which is also needed for other commands
when going stateless.

Fixes: IOTOS-1498

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>