### PR TITLE
recipes-core/packagegroups: add missing app-framework packagegroup.

### DIFF
--- a/meta-ostro/recipes-core/packagegroups/packagegroup-app-framework.bb
+++ b/meta-ostro/recipes-core/packagegroups/packagegroup-app-framework.bb
@@ -1,0 +1,8 @@
+SUMMARY = "Ostro Application Framework"
+LICENSE = "MIT"
+
+inherit packagegroup
+
+RDEPENDS_${PN} = " \
+    iot-app-fw \
+"


### PR DESCRIPTION
The actual declaration/definition of the app-framework packagegroup
was missing from commit 979819f1c854b3199cdc172115c9993f22984be0.
Add it now.
