### PR TITLE
README.rst: add layers that are now used in the project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 About the ostro-os repository
-===========================
+=============================
 
 The ostro-os repository is a combination of several different components
 in a single repository. It contains everything that is needed to build
@@ -9,18 +9,20 @@ Ostro OS:
 - openembedded-core
 - meta-intel
 - meta-ostro
-- meta-oic
-- meta-intel-iot-middleware
-- meta-intel-iot-security
 - meta-ostro-fixes
 - meta-ostro-bsp
-- meta-iot-web
-- meta-yocto
-- meta-iotqa
+- meta-intel-iot-security
 - meta-appfw
+- meta-openembedded
+- meta-oic
+- meta-intel-iot-middleware
+- meta-iotqa
+- meta-iot-web
+- meta-security-isafw
+- meta-yocto
 - meta-java
 - meta-soletta
-- meta-openembedded
+- meta-swupd
 
 The top-level directory comes from openembedded-core and meta-ostro
 (including this README.rst), everything else is in its own


### PR DESCRIPTION
Add layers that are now used by the Ostro Project but not yet
documented in the README.rst file (namely: meta-security-isafw
and meta-swupd). Also shuffle the order to match the order in
which these are listed in conf/combo-layer.conf.

[skip ci]

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>