### PR TITLE
ostro-image.bbclass: revert "Ostro: Start shell on init failure."

### DIFF
--- a/meta-ostro/classes/ostro-image.bbclass
+++ b/meta-ostro/classes/ostro-image.bbclass
@@ -381,10 +381,6 @@ OSTRO_IMAGE_STRIP_SMACK = "${@ 'ostro_image_strip_smack' if not bb.utils.contain
 do_rootfs[postfuncs] += "${OSTRO_IMAGE_STRIP_SMACK}"
 DEPENDS += "${@ 'attr-native' if '${OSTRO_IMAGE_STRIP_SMACK}' else '' }"
 
-# Debug option:
-# in case of problems during the transition from initramfs to rootfs, spawn a shell.
-APPEND_append = " init_fatal_sh"
-
 # Mount read-only at first. This gives systemd a chance to run fsck
 # and then mount read/write.
 APPEND_append = " ro"


### PR DESCRIPTION
This reverts commit 774953a0dec3e0227b243a14c16997ad82f1bef8.

We do not want debug options enabled unconditionally. In this case,
the debug option has not been needed for a while, so it is easier
to remove the feature entirely.

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>