### PR TITLE
ostro.conf: disable static libraries

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -147,6 +147,7 @@ VIRTUAL-RUNTIME_init_manager = "systemd"
 VIRTUAL-RUNTIME_initscripts = ""
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit pulseaudio"
 
+require conf/distro/include/no-static-libs.inc
 require conf/distro/include/ostro_security_flags.inc
 require conf/distro/include/ostro-x11.inc
 


### PR DESCRIPTION
Poky switched to disabling static libraries in 2.1. Ostro OS should do
the same, see commit for the reasoning.

I have not actually tested the change. This will have to be done as
part of CI and QA testing.