### PR TITLE
ostro-image.bbclass: temporarily disable soletta-dev-app

### DIFF
--- a/meta-ostro/classes/ostro-image.bbclass
+++ b/meta-ostro/classes/ostro-image.bbclass
@@ -46,7 +46,6 @@ OSTRO_IMAGE_PKG_FEATURES = " \
     python-runtime \
     qatests \
     soletta \
-    soletta-tools \
     tools-debug \
     tools-develop \
     tools-interactive \

--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -404,3 +404,7 @@ APPEND_append = " fsck.mode=skip"
 # swupd-server-native is used so this is a safe choice.
 # The failure is: "autoreconf execution failed."
 EXCLUDE_FROM_WORLD_pn-swupd-server = "1"
+
+# soletta-dev-app breaks builds in CI due to npm install and network
+# problems with it. Temporarily skip the build.
+EXCLUDE_FROM_WORLD_pn-soletta-dev-app = "1"


### PR DESCRIPTION
The npm install used in the .bb is causing troubles in CI build
environment and it makes many pull request to fail due to network
issues.

Temporarily disable soletta-dev-app from the image to get integration
moving faster.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>