### PR TITLE
systemd-sysusers.bbclass: set login shell to /sbin/nologin

### DIFF
--- a/meta-ostro/classes/systemd-sysusers.bbclass
+++ b/meta-ostro/classes/systemd-sysusers.bbclass
@@ -23,7 +23,7 @@ systemd_sysusers_create () {
                     fi
                     comment=$(echo "$remaining" | cut -d '"' -f 2)
                     home=$(echo "$remaining" | cut -d '"' -f 3 | sed -e 's/^ *//' -e 's/ *$//')
-                    perform_useradd "${IMAGE_ROOTFS}" "$opts $uid --home-dir ${home:-/} --comment \"$comment\" $name" 10
+                    perform_useradd "${IMAGE_ROOTFS}" "$opts $uid --home-dir ${home:-/} --shell /sbin/nologin --comment \"$comment\" $name" 10
                     ;;
                   "")
                     ;;


### PR DESCRIPTION
systemd specifies that all users have sysusers will end up having
/sbin/login, which was missing from the helper class, leading to
unintentionally creating the users with /bin/sh instead.

@ipuustin that fixes the problem you found. Please review.