### PR TITLE
DOC: duplicate platforms link in doc menu

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,7 +17,6 @@ Getting Started
    :maxdepth: 1
 
    quick_start/about
-   quick_start/platforms
    quick_start/quick_start
    quick_start/access-support
 


### PR DESCRIPTION
Fixes: IOTOS-1474

platforms.rst was listed twice in TOC menu

[skip ci]

Signed-off-by: David Kinder <david.b.kinder@intel.com>