### PR TITLE
ostro-multilib.conf: Fix galileo build

### DIFF
--- a/meta-ostro/conf/ostro-multilib.conf
+++ b/meta-ostro/conf/ostro-multilib.conf
@@ -24,3 +24,7 @@ EXCLUDE_FROM_WORLD_virtclass-multilib-lib32 = "1"
 # It would probably be nicer to do this as a linux-uclibc
 # override but that doesn't cover lib32-gcc-runtime
 SECURITY_CFLAGS_virtclass-multilib-lib32 = ""
+
+# libgcc produces a broken symlink during multilib_do_install to the non-existent 32 bit libgcc directory.
+# This breaks sanity checks. Removing lib32 from its multilib variant prevent this from happening
+MULTILIB_VARIANTS_remove_pn-libgcc = "lib32"


### PR DESCRIPTION
This is a test PR.

Multilib build fails currently for ostro-image-swupd, as libgcc creates a symlink to the 32 bit glibc directory. As we use uclibc as the 32 bit library instead, this symlink is broken, and a sanity check fails during a swupd related task.

Suppress this symlink creation instead by removing 'lib32' from MULTILIB_VARIANTS-variable for libgcc, so that libgcc recipe does not realize we are using multilib feature.  

Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>

