### PR TITLE
ostro.conf: improve message for components not whitelisted

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -177,7 +177,7 @@ INHERIT += "ostro-sanity"
 # recipes. Add or remove layers there as needed when changing the white
 # lists below.
 INHERIT += "whitelist"
-PNWHITELIST_REASON = "not supported by ${DISTRO}"
+PNWHITELIST_REASON = "not supported by the ${DISTRO_NAME} (not on the whitelist)"
 
 PNWHITELIST_LAYERS = " \
     efl-layer \


### PR DESCRIPTION
The error message thrown when attempting to build a component
that is not included in the Ostro OS whitelist is not very helpful.
This commit improves it a little by giving the reason why building
such component is skipped.

[skip ci]

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>