### PR TITLE
ostro.conf: disable SSTATE locked sigs checks

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -28,6 +28,12 @@ SDK_RECRDEP_TASKS = "do_deploy_files do_uefiapp"
 # Blacklist inherited classes that break proper data restore from SSTATE when populating the SDK.
 SDK_INHERIT_BLACKLIST = "buildhistory icecc buildhistory-extra buildstats-summary archiver isafw test-iot"
 
+# Disable SSTATE locked sigs checks. SDK_INHERIT_BLACKLISTed classes
+# used in CI (and mirrored SSTATE) cause locked signature file check
+# failures with eSDK installation. Until the blacklisted classes are
+# fixed, SSTATE checks need to be run in self-tests.
+SIGGEN_LOCKEDSIGS_TASKSIG_CHECK = "none"
+
 # When building in a CI system with swupd enabled, OS_VERSION must be
 # set to a consistent value for all builds. See ostroproject-ci.inc
 # for an example how that works with Jenkins.


### PR DESCRIPTION
The SDK_INHERIT_BLACKLISTed classes used in CI (and mirrored SSTATE)
cause locked signature file check failures with eSDK installation.

Until the blacklisted classes are fixed, SSTATE checks need to be
run in self-tests.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>