### PR TITLE
python-pygobject: avoid gnome-common dependency

### DIFF
--- a/meta-fixes/recipes-devtools/python/python-pygobject_%.bbappend
+++ b/meta-fixes/recipes-devtools/python/python-pygobject_%.bbappend
@@ -1,0 +1,6 @@
+# This dependency is redundant because gnome-common-native is
+# sufficient and gets pulled in by gnomebase.bbclass.
+#
+# We remove it here to avoid building a useless target
+# component.
+DEPENDS_remove = "gnome-common"


### PR DESCRIPTION
gnome-common is not really needed (the native counterpart
pulled invia gnomebase.bbclass is enough). We can make
Ostro OS simpler and easier to review by not building it.

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>