### PR TITLE
meta-ostro: Remove java

### DIFF
--- a/meta-ostro/classes/ostro-image.bbclass
+++ b/meta-ostro/classes/ostro-image.bbclass
@@ -40,7 +40,6 @@ OSTRO_IMAGE_PKG_FEATURES = " \
     connectivity \
     devkit \
     iotivity \
-    java-jdk \
     nodejs-runtime \
     nodejs-runtime-tools \
     python-runtime \

--- a/meta-ostro/conf/bblayers.conf.sample
+++ b/meta-ostro/conf/bblayers.conf.sample
@@ -47,7 +47,6 @@ OSTRO_LAYERS += "##OEROOT##/meta-openembedded/meta-python"
 # OSTRO_LAYERS += "##OEROOT##/meta-openembedded/meta-webserver"
 # OSTRO_LAYERS += "##OEROOT##/meta-openembedded/meta-xfce"
 # OSTRO_LAYERS += "##OEROOT##/meta-openembedded/toolchain-layer"
-OSTRO_LAYERS += "##OEROOT##/meta-java"
 OSTRO_LAYERS += "##OEROOT##/meta-soletta"
 
 BBLAYERS ?= "${OSTRO_LAYERS}"

--- a/meta-ostro/recipes-core/packagegroups/packagegroup-java-jdk.bb
+++ b/meta-ostro/recipes-core/packagegroups/packagegroup-java-jdk.bb
@@ -4,5 +4,4 @@ LICENSE = "MIT"
 inherit packagegroup
 
 RDEPENDS_${PN} = " \
-    openjdk-8-jdk \
 "


### PR DESCRIPTION
Temporarily removes java from Ostro to avoid build breakages during
upstream switch.

Dependency for https://github.com/ostroproject/ostro-os/pull/80

Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>