### PR TITLE
ostro-image-swupd.bb: prepare for BUNDLE_FEATURES API change in meta-swupd

### DIFF
--- a/meta-ostro/recipes-image/images/ostro-image-swupd.bb
+++ b/meta-ostro/recipes-image/images/ostro-image-swupd.bb
@@ -60,6 +60,16 @@ BUNDLE_CONTENTS[world] = " \
     ${BUNDLE_CONTENTS_WORLD} \
 "
 
+# meta-swupd will switch from mapping "world-dev" to "world" +
+# ptest-pkgs. Instead it will expect us to provide the following
+# two variables. Already do that now to ease the transition:
+BUNDLE_CONTENTS[world-dev] = " \
+    ${BUNDLE_CONTENTS_WORLD} \
+"
+BUNDLE_FEATURES[world-dev] = " \
+    dev-pkgs \
+"
+
 # When swupd bundles are enabled, choose explicitly which images
 # are created. The base image will only have the core-os bundle.
 #


### PR DESCRIPTION
meta-swupd was updated such that the API changed, causing
https://github.com/ostroproject/ostro-os/pull/60 to fail unless this
PR here gets merged into meta-ostro.

There's no big risk associated with it, but also no pressing need as
the updates of ostro-os are currently done manually and can exclude
meta-swupd.