### PR TITLE
ostro.conf: Blaclkist BB_NUMBER_PARSE_THREADS for SDK

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -28,6 +28,12 @@ SDK_RECRDEP_TASKS = "do_deploy_files do_uefiapp"
 # Blacklist inherited classes that break proper data restore from SSTATE when populating the SDK.
 SDK_INHERIT_BLACKLIST = "buildhistory icecc buildhistory-extra buildstats-summary archiver isafw test-iot"
 
+# The variable BB_NUMBER_PARSE_THREADS set in CI in order to
+# limit the number of parse threads should not leak to the user's
+# environment since it may increase SDK installation time and
+# worsen runtime performance on capable systems.
+SDK_LOCAL_CONF_BLACKLIST_append = " BB_NUMBER_PARSE_THREADS"
+
 # Disable SSTATE locked sigs checks. SDK_INHERIT_BLACKLISTed classes
 # used in CI (and mirrored SSTATE) cause locked signature file check
 # failures with eSDK installation. Until the blacklisted classes are


### PR DESCRIPTION
The variable BB_NUMBER_PARSE_THREADS set in CI in order to
limit the number of parse threads should not leak to the user's
environment since it may increase SDK installation time and
worsen runtime performance on capable systems.

Fixes: IOTOS-1548

Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>