### PR TITLE
bmap-tools: fix deploy class usage for machine independent files

### DIFF
--- a/meta-ostro/recipes-devtools/bmap-tools/bmap-tools_3.2.bb
+++ b/meta-ostro/recipes-devtools/bmap-tools/bmap-tools_3.2.bb
@@ -24,6 +24,7 @@ do_install_append_class-native() {
 }
 
 do_deploy[sstate-outputdirs] = "${DEPLOY_DIR_TOOLS}"
+do_deploy[stamp-extra-info] = ""
 do_deploy_class-native() {
     cp bmaptool __main__.py
     python -m zipfile -c bmaptool.zip bmaptools __main__.py


### PR DESCRIPTION
During discussion of including bmap-tools to OE-Core it was discovered
that bmap-tools install machine independent file in deploy directory,
but task is machine dependant. This patch fixes inconsistency.

Reference: https://bugzilla.yoctoproject.org/show_bug.cgi?id=9414

Signed-off-by: Alexander Kanevskiy <kad@linux.intel.com>