### PR TITLE
DOC: Fix incorrect use of ::: for code blocks

### DIFF
--- a/doc/howtos/authorized-keys.rst
+++ b/doc/howtos/authorized-keys.rst
@@ -18,7 +18,7 @@ Generating a Private/Public Key Pair
 ====================================
 
 On Linux systems (or Windows systems with `Git Bash`_ installed) use the ``ssh-keygen`` utility to generate
-an ssh key pair by following its instructions ::
+an ssh key pair by following its instructions::
 
    $ ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
 
@@ -60,7 +60,7 @@ Build-Time Configuration of Authorized Keys
 The recommended approach for enabling remote ``ssh`` access is to install authorized public ssh keys by 
 setting OSTRO_ROOT_AUTHORIZED_KEYS in your ``local.conf`` configuration file and building them into your image.
 
-#. Look in your ``local.conf`` file and find the line:::
+#. Look in your ``local.conf`` file and find the line::
 
    # OSTRO_ROOT_AUTHORIZED_KEYS = "ssh-rsa AAA...== john@example.com\nssh-dss AA...FPaQ== joan@example.com"
 
@@ -71,7 +71,7 @@ setting OSTRO_ROOT_AUTHORIZED_KEYS in your ``local.conf`` configuration file and
 
 #. Make note of your devices IP address using ``ifconfig`` for example, if you've got a local console or serial port connection.
 
-#. Login from your host using ``ssh`` with your private key (from host) and the IP address of your device, for example: ::
+#. Login from your host using ``ssh`` with your private key (from host) and the IP address of your device, for example::
 
     $ ssh root@192.168.2.2 -i $HOME/.ssh/id_rsa
 
@@ -106,7 +106,7 @@ private key.
           # cat key/id_rsa.pub >> ~root/.ssh/authorized_keys
   
 #. Make note of your devices IP address (using ``ifconfig`` for example) and reboot the device.
-#. Login from your host using ``ssh`` with your private key (from host) and the IP address of your device, for example: ::
+#. Login from your host using ``ssh`` with your private key (from host) and the IP address of your device, for example::
 
     $ ssh root@192.168.2.2 -i $HOME/.ssh/id_rsa
 

--- a/doc/howtos/booting-and-installation.rst
+++ b/doc/howtos/booting-and-installation.rst
@@ -248,7 +248,7 @@ In our setup steps below, we're using an 8GB microSD card in an SD adapter that'
 
 2. Now we're ready to prepare the microSD card.  Make sure the microSD card isn't already mounted
    and verify it is using MBR partitions. (Remember, your
-   device name maybe different than what we're using in our examples.) Run ::
+   device name maybe different than what we're using in our examples.) Run::
 
    $ sudo umount /dev/mmcblk0*
    $ sudo fdisk /dev/mmcblk0
@@ -310,7 +310,7 @@ In our setup steps below, we're using an 8GB microSD card in an SD adapter that'
 
 #.  Before unmounting the device, we also need to add the device tree blob file (``zImage-am335x-boneblack.dtb``)
     that you downloaded (or from your own build).
-    Note that this step renames the file (without the ``zImage-`` prefix) to match what's expected by the kernel ::
+    Note that this step renames the file (without the ``zImage-`` prefix) to match what's expected by the kernel. ::
 
      $ sudo cp zImage-am335x-boneblack.dtb rootfs/boot/am335x-boneblack.dtb
      $ sudo umount rootfs
@@ -322,7 +322,7 @@ Note:  The normal boot sequence is to use the on-board flash first (eMMC), then 
 then the USB port, and finally the serial port. You may need to use the **S2** alternate boot button,
 by holding it down at power up, to change the boot order to use the microSD card first instead of eMMC first.
 
-Once booted from the microSD card, you can prevent boot from eMMC by using (on the BeagleBone Black) ::
+Once booted from the microSD card, you can prevent boot from eMMC by using (on the BeagleBone Black)::
 
    $ dd if=/dev/zero of=/dev/mmcblk1 bs=4M count=1
 
@@ -330,7 +330,7 @@ Once booted from the microSD card, you can prevent boot from eMMC by using (on t
 Converting from GPT to MBR Partitions
 -------------------------------------
 
-On a linux system run the ``gdisk`` utility *(Note: your microSD card device name may be different than in this example)* ::
+On a linux system run the ``gdisk`` utility *(Note: your microSD card device name may be different than in this example)*::
 
    $ sudo umount /dev/mmcblk0*
    $ sudo gdisk /dev/mmcblk0

--- a/doc/howtos/ip-address-config.rst
+++ b/doc/howtos/ip-address-config.rst
@@ -26,7 +26,7 @@ Enabling Network Technologies
 =============================
 
 Before a network transport (such as WiFi) can be used, it must be enabled in ConnMan. You can check to see what technologies
-have already been enabled with the command :: 
+have already been enabled with the command:: 
 
    $ connmanctl technologies
 
@@ -45,7 +45,7 @@ ConnMan refers to network devices as services. To configure a static IP address 
 you first find the name of the service assigned by ConnMan and then provide the IP address information, as 
 shown in these steps: 
 
-#. List the services available on your device ::
+#. List the services available on your device::
 
      $ connmanctl services
 
@@ -65,7 +65,7 @@ shown in these steps:
 
      $ connmanctl config <service> –ipv4 manual <ip address> <netmask> <gateway> 
 
-   For example, using the service name discovered above: ::
+   For example, using the service name discovered above::
 
      $ connmanctl config ethernet_0008a209b525_cable –ipv4 manual 192.168.1.4 255.255.255.0 192.168.1.1
 
@@ -81,7 +81,8 @@ for the following example.
 
 Here are the steps to connect to a wireless network using DHCP:
 
-#. Open connmanctl in interactive mode, enable WiFi (if you haven't already), and scan for new WiFi services (available SSIDs)::
+#. Open connmanctl in interactive mode, enable WiFi (if you haven't already), and scan for new 
+   WiFi services (available SSIDs)::
 
      $ connmanctl
      $ connmanctl> enable wifi 
@@ -91,11 +92,11 @@ Here are the steps to connect to a wireless network using DHCP:
 #. To connect to a secure
    WiFi network, we need to register the agent to handle user requests. This agent is used by the daemon to 
    call back an application when attention or input is needed. If you're connecting to an (unsecured) open access point you 
-   can skip this step ::
+   can skip this step. ::
 
      $ connmanctl> agent on
 
-#. Use the wireless network name and the service name displayed by the ``services`` command to connect to that network ::  
+#. Use the wireless network name and the service name displayed by the ``services`` command to connect to that network. ::  
 
      $ connmanctl> connect wifi_<MAC_ADDR>_<SSID_HEX>_managed_psk
 
@@ -104,7 +105,7 @@ Here are the steps to connect to a wireless network using DHCP:
 
    An open unsecured access point would be displayed by the ``services`` command with an ``_managed_none`` suffix.
 
-   For example ::
+   For example::
 
      $ connmanctl> scan wifi
      $ connmanctl> services

--- a/doc/howtos/modifying-ostro-kernel.rst
+++ b/doc/howtos/modifying-ostro-kernel.rst
@@ -17,7 +17,7 @@ Preparing the Kernel Source Code
 ================================
 
 Assuming the repository where you have cloned the Ostro source code is called ``ostro-os`` 
-generate the initial image using these commands:::
+generate the initial image using these commands::
 
    cd ostro-os
    source oe-init-build-env
@@ -32,11 +32,11 @@ The source code is located in the Yocto `${WORKDIR}`_ which
 is: ``tmp-glibc/work/corei7-64-intel-common-iotos-linux/linux-yocto/<kernel-version>/linux-corei7-64-intel-common-standard-build/source``. 
 Make all the changes that you need, source code modifications including ``Kconfig`` and ``Makefile`` files if relevant.
 
-* If needed, modify the kernel configuration to enable your changes:::
+* If needed, modify the kernel configuration to enable your changes::
 
     bitbake linux-yocto -c menuconfig
 
-* Recompile the (modified) kernel::: 
+* Recompile the (modified) kernel:: 
 
     bitbake -f linux-yocto -c compile
 
@@ -44,14 +44,14 @@ Make all the changes that you need, source code modifications including ``Kconfi
   * Using the ``-f`` option forces the rebuild because :command:`bitbake` will not detect 
     changes you made in the Yocto `${WORKDIR}`_ and will think it has already successfully built the kernel.
 
-* Compile all drivers (modules)::: 
+* Compile all drivers (modules):: 
   
     bitbake -f linux-yocto -c compile_kernelmodules
 
 Generating an Image with all the Changes
 ========================================
 
-* To build a full image with this new kernel:::
+* To build a full image with this new kernel::
   
     bitbake ostro-image
 

--- a/doc/howtos/software-update-server.rst
+++ b/doc/howtos/software-update-server.rst
@@ -116,7 +116,7 @@ Step 1: Review and optionally modify the list of bundles
 --------------------------------------------------------
 Ostro already defines some bundles, and users can define additional ones.
 
-Example:::
+Example::
 
   SWUPD_BUNDLES += "sudo_bundle"
   BUNDLE_CONTENTS[sudo_bundle] = "sudo"

--- a/doc/quick_start/contributor-guide.rst
+++ b/doc/quick_start/contributor-guide.rst
@@ -249,7 +249,7 @@ Prepare your patch
 
 #. Create a repository on your local computer to your fork.  If you have ssh keys generated you can register your 
    public key on your GitHub account (SSH and GPG keys in your Personal Settings on Git Hub) to be authorized.  
-   Otherwise, you can clone with "https" and specify your GitHub username and password:::
+   Otherwise, you can clone with "https" and specify your GitHub username and password::
  
       $ git clone github.com:<your-username>/meta-ostro                # if you've registered your ssh key
       $ git clone https://github.com/<your-username>/meta-ostro.git    # if not use this (and your GitHub username/password)
@@ -261,7 +261,7 @@ Prepare your patch
 
       $ git remote -v        # verify origin (your fork) and remote (Ostro OS master) are defined as expected
 
-#. Create a new branch to work on your patch:::
+#. Create a new branch to work on your patch::
 
       $ git fetch upstream
       $ git checkout -b my-patched-branch upstream/master
@@ -277,19 +277,19 @@ Prepare your patch
 
    See the `Yocto Project Managing Layers`_ documentation for more usage details.
 
-   When ready, run bitbake to start the build:::
+   When ready, run bitbake to start the build::
 
       $ bitbake -k ostro-image-noswupd        # for example, other target images are available too
 
 #. Commit your changes and rebase onto master
    After you’ve tested and verified your change does what was intended, you can commit your change locally. 
-   Make sure that you follow the `Code Review Process Guidelines`_ described earlier in this document:::
+   Make sure that you follow the `Code Review Process Guidelines`_ described earlier in this document::
 
       $ git commit -a -s                    # follow guidelines for the commit message
       $ git push origin my-patch-branch     # push your local branch up to your forked GitHub repo
 
    Depending on how long you have worked on your patch, it may be that the master branch has evolved since you branched 
-   it off. If that is the case, you should rebase your working branch onto master before sending the Pull Request (PR):::
+   it off. If that is the case, you should rebase your working branch onto master before sending the Pull Request (PR)::
 
 
       $ git rebase upstream/master
@@ -297,17 +297,17 @@ Prepare your patch
 #. Create a Pull Request (PR)
    Once your change is in your forked version (up on GitHub), use your web browser to submit your PR:
 
-     * Navigate to your branch: https://github.com/<username>/meta-ostro/tree/my-patched-branch (the branch name you
-       created earlier).
-     * Click on "Compare & pull request" button From there you can see your changes and create a Pull Request (PR) to the 
-       master branch for that component.
+   * Navigate to your branch: https://github.com/<username>/meta-ostro/tree/my-patched-branch (the branch name you
+     created earlier).
+   * Click on "Compare & pull request" button From there you can see your changes and create a Pull Request (PR) to the 
+     master branch for that component.
 
 
 7. Respond to Pull Request (PR) Comments
    You may be asked to update or re-work your patch as part of the review process. 
    The easiest way to keep the discussion going in the same Pull Request is to force-push a revised commit to your 
    forked repository. GitHub will automatically update the Pull Request with the latest changes.  Using amended
-   commits is preferred over a PR with multiple commits and helps make reviewing the cumulative changes much easier:::
+   commits is preferred over a PR with multiple commits and helps make reviewing the cumulative changes much easier::
 
 
       $ git commit --amend


### PR DESCRIPTION
Scanned through all .rst files to change incorrect code block
ReST tag shorthand from ":::" to "::"  (settled on using "::" vs. ": ::" consistently)
and force pushed.

[skip ci]

Signed-off-by: David Kinder <david.b.kinder@intel.com>