### PR TITLE
buildhistory-extra.bbclass: record ${S} and friends literally in history

### DIFF
--- a/meta-ostro/classes/buildhistory-extra.bbclass
+++ b/meta-ostro/classes/buildhistory-extra.bbclass
@@ -28,10 +28,18 @@ python buildhistory_extra_emit_pkghistory() {
 
     import codecs
 
-    relpath = os.path.dirname(d.getVar('TOPDIR', True))
     pkghistdir = d.getVar('BUILDHISTORY_DIR_PACKAGE', True)
     if not os.path.exists(pkghistdir):
         bb.utils.mkdirhier(pkghistdir)
+
+    # Make the recorded information independent of varying paths.
+    # Some recipes use destsuffix=${S}/... to fetch components
+    # into their main source tree. The other variable do not show
+    # up (yet), but might eventually.
+    d = d.createCopy()
+    for var in ('S', 'WORKDIR', 'BASE_WORKDIR', 'TMPDIR'):
+        d.delVar(var)
+    relpath = os.path.dirname(d.getVar('TOPDIR', True))
 
     # Record PV in the "latest" file. This duplicates work in
     # buildhistory_emit_pkghistory(), but we do not know whether


### PR DESCRIPTION
iotivity has
git://github.com/01org/tinycbor.git;protocol=https;name=cbor;destsuffix=${S}/extlibs/tinycbor/tinycbor
as entry in its SRC_URI. When we allow S to be expanded, we end up
with paths that vary from build to build.

Besides causing churn in the build history, it also causes iotivity to
show up once per architecture in the patch summary.