### PR TITLE
iotivity-node: fix signed/unsigned char compiler problems

### DIFF
--- a/meta-ostro/fixes/meta-iot-web/recipes-web/iotivity-node/files/oc-payload.cc-fix-signed-unsigned-char-issues.patch
+++ b/meta-ostro/fixes/meta-iot-web/recipes-web/iotivity-node/files/oc-payload.cc-fix-signed-unsigned-char-issues.patch
@@ -1,0 +1,73 @@
+From 01acd25c0e36eec22807b2ac0c4c8493d7702bd6 Mon Sep 17 00:00:00 2001
+From: Patrick Ohly <patrick.ohly@intel.com>
+Date: Mon, 9 May 2016 08:46:14 +0200
+Subject: [PATCH] oc-payload.cc: fix signed/unsigned char issues
+
+When char == signed char, conversion to and from uint_8 fails in some
+places. Started to happen recently in Ostro OS, perhaps because of a
+compiler update.
+
+The conversion of sid is straightforward.
+
+OCSecurityPayload->securityData is less obvious: it is an uint_8
+pointer, which seems to end up getting converted to a boolean instead
+of a character string. The typecast unfortunately has to be done
+inside the macro, reducing its type safety.
+
+../src/structures/oc-payload.cc: In function 'v8::Local<v8::Object> js_OCDiscoveryPayload(OCDiscoveryPayload*)':
+../src/structures/oc-payload.cc:240:30: error: invalid conversion from 'char*' to 'uint8_t* {aka unsigned char*}' [-fpermissive]
+              js_SID(payload->sid));
+
+In file included from ../src/structures/oc-payload.cc:18:0:
+../src/structures/oc-payload.cc: In function 'v8::Local<v8::Object> js_OCSecurityPayload(OCSecurityPayload*)':
+../src/structures/../common.h:63:45: error: 'Nan::imp::FactoryBase<v8::Boolean>::return_t {aka class v8::Local<v8::Boolean>}' has no member named 'ToLocalChecked'
+              Nan::New((source)->memberName).ToLocalChecked());      \
+                                             ^
+../src/structures/oc-payload.cc:312:3: note: in expansion of macro 'SET_STRING_IF_NOT_NULL'
+   SET_STRING_IF_NOT_NULL(returnValue, payload, securityData);
+
+Upstream-Status: Submitted [https://github.com/otcshare/iotivity-node/issues/49]
+Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>
+---
+ src/common.h                 | 2 +-
+ src/structures/oc-payload.cc | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/common.h b/src/common.h
+index b0b5c59..60c89fe 100644
+--- a/src/common.h
++++ b/src/common.h
+@@ -60,7 +60,7 @@
+ #define SET_STRING_IF_NOT_NULL(destination, source, memberName)     \
+   if ((source)->memberName) {                                       \
+     Nan::Set((destination), Nan::New(#memberName).ToLocalChecked(), \
+-             Nan::New((source)->memberName).ToLocalChecked());      \
++             Nan::New(reinterpret_cast<const char *>((source)->memberName)).ToLocalChecked()); \
+   }
+ 
+ #define SET_VALUE_ON_OBJECT(destination, type, source, memberName) \
+diff --git a/src/structures/oc-payload.cc b/src/structures/oc-payload.cc
+index d65bedd..fa31fda 100644
+--- a/src/structures/oc-payload.cc
++++ b/src/structures/oc-payload.cc
+@@ -237,7 +237,7 @@ static Local<Object> js_OCDiscoveryPayload(OCDiscoveryPayload *payload) {
+ 
+   if (payload->sid) {
+     Nan::Set(returnValue, Nan::New("sid").ToLocalChecked(),
+-             js_SID(payload->sid));
++             js_SID(reinterpret_cast<unsigned char *>(payload->sid)));
+   }
+ 
+   // Count the resources
+@@ -266,7 +266,7 @@ static Local<Object> js_OCDevicePayload(OCDevicePayload *payload) {
+ 
+   if (payload->sid) {
+     Nan::Set(returnValue, Nan::New("sid").ToLocalChecked(),
+-             js_SID(payload->sid));
++             js_SID(reinterpret_cast<unsigned char *>(payload->sid)));
+   }
+ 
+   SET_STRING_IF_NOT_NULL(returnValue, payload, deviceName);
+-- 
+2.1.4
+

--- a/meta-ostro/fixes/meta-iot-web/recipes-web/iotivity-node/iotivity-node.bbappend
+++ b/meta-ostro/fixes/meta-iot-web/recipes-web/iotivity-node/iotivity-node.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "${@ 'file://oc-payload.cc-fix-signed-unsigned-char-issues.patch' if '${SRCREV}' == '38f76790e2d0f4960b0f3360c7bbcdf5a69907f4' else '' }"


### PR DESCRIPTION
Started to fail in recent CI pull, exact reason unknown. The code
clearly isn't handling signed char correctly, hence the patch.