### PR TITLE
buildhistory-extra.bbclass: fix storing of extra info

### DIFF
--- a/meta-ostro/classes/buildhistory-extra.bbclass
+++ b/meta-ostro/classes/buildhistory-extra.bbclass
@@ -23,7 +23,12 @@ SSTATEPOSTINSTFUNCS[vardepvalueexclude] .= "| buildhistory_extra_emit_pkghistory
 
 python buildhistory_extra_emit_pkghistory() {
     bb.note('buildhistory_extra_emit_pkghistory %s' % d.getVar('BB_CURRENTTASK', True))
-    if not d.getVar('BB_CURRENTTASK', True) in ['populate_sysroot', 'populate_sysroot_setscene']:
+    # Some recipes only get installed in a sysroot (native), others
+    # only get packaged (target, when nothing depends on them being installed in the sysroot),
+    # and some get installed and packaged (target, when something depends on them in the sysroot).
+    # We hook into all of these tasks to ensure that we don't miss recipes, even though
+    # that means that we'll do the work twice in some cases.
+    if not d.getVar('BB_CURRENTTASK', True) in ['populate_sysroot', 'populate_sysroot_setscene', 'packagedata', 'packagedata_setscene']:
         return 0
 
     import codecs


### PR DESCRIPTION
The buildhistory entry for #440 lacks, for example, the LICENSE
information in adwaita-icon-theme because the entire 'variables' file
was never written.

See https://ostroproject.org/jenkins/job/build_edison/1414/consoleFull and
ostro-os_master/2016-05-03_03-01-12-build-441/761672d39c4822e6c18bc7b78f32446c2a5d2eb6/intel-quark

@kad please review, I'd like to include this for the next master build today.