### PR TITLE
VirtualBox appliance generation: Change nic mode, delete temporary files and rename conflicting directory

### DIFF
--- a/meta-ostro/classes/image-dsk.bbclass
+++ b/meta-ostro/classes/image-dsk.bbclass
@@ -109,6 +109,7 @@ create_ova() {
 
   # erase temp files created during appliance generation
   rm -rf "/tmp/.vbox-${VBOX_IPC_SOCKETID}-ipc"
+  rm -rf ${WORK_FOLDER}
 }
 
 COMPRESS_CMD_ova = "create_ova"

--- a/meta-ostro/classes/image-dsk.bbclass
+++ b/meta-ostro/classes/image-dsk.bbclass
@@ -67,6 +67,8 @@ create_ova() {
   STORAGE_DEVICE="0"
   STORAGE_DEVICE_TYPE="hdd"
 
+  # Network adapter mode
+  NIC_MODE="bridged"
 
   RAW_IMAGE="${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.dsk"
   VIRTUALBOX_IMAGE="${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.vmdk"
@@ -96,6 +98,9 @@ create_ova() {
 
   # attach the .vmdk image as hard drive
   ${VIRTUALBOX_EXECUTABLE} storageattach ${VM_NAME} --storagectl ${STORAGE_NAME} --medium ${VIRTUALBOX_IMAGE} --port ${STORAGE_PORT} --device ${STORAGE_DEVICE} --type ${STORAGE_DEVICE_TYPE}
+
+  # Set the network adapter mode
+  ${VIRTUALBOX_EXECUTABLE} modifyvm ${VM_NAME} --nic1 ${NIC_MODE}
 
   # export the image
   ${VIRTUALBOX_EXECUTABLE} export ${VM_NAME} --output ${DEPLOY_DIR_IMAGE}/${APPLIANCE_NAME} --ovf20


### PR DESCRIPTION
VirtualBox uses a directory under /tmp for ipc. This can cause issues
if user already has VirtualBox installed, as the directory may already
exist and may be owned by root. The directory is renamed to avoid any
name collisions.

The VirtualBox working directory is also deleted, as this gets published, which is not intended.

Finally VirtualBox NIC is configured to use bridged mode instead of the default NAT, as this makes connecting to the VM easier from the host machine.

Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>