### PR TITLE
update image content and configuration

### DIFF
--- a/meta-ostro-fixes/meta-fixes/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/meta-ostro-fixes/meta-fixes/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,0 +1,6 @@
+# Upstream-Status: Submitted [https://bugzilla.yoctoproject.org/show_bug.cgi?id=9523]
+
+do_install_ptest_append () {
+    # openssl.inc links to /lib/libcrypto.a instead of the correct /usr/lib/libcrypto.a
+    ln -sf ${libdir}/libcrypto.a ${D}${PTEST_PATH}
+}

--- a/meta-ostro/recipes-image/images/ostro-image-swupd.bb
+++ b/meta-ostro/recipes-image/images/ostro-image-swupd.bb
@@ -61,11 +61,20 @@ BUNDLE_CONTENTS_WORLD ?= " \
     ${OSTRO_IMAGE_INSTALL_DEV} \
 "
 
+# The additional features automatically add development and
+# ptest packages for everything that gets installed in the
+# bundle.
+#
+# It would be useful to also add debug packages (via dbg-pkgs),
+# but that increases the size too much (ostro-image-swupd-dev content
+# no longer fits for Edison and has very little free space left
+# in the 4GB images used elsewhere).
 BUNDLE_CONTENTS[world-dev] = " \
     ${BUNDLE_CONTENTS_WORLD} \
 "
 BUNDLE_FEATURES[world-dev] = " \
     dev-pkgs \
+    ptest-pkgs \
 "
 
 # When swupd bundles are enabled, choose explicitly which images

--- a/meta-ostro/recipes-image/images/ostro-image-swupd.bb
+++ b/meta-ostro/recipes-image/images/ostro-image-swupd.bb
@@ -61,13 +61,6 @@ BUNDLE_CONTENTS_WORLD ?= " \
     ${OSTRO_IMAGE_INSTALL_DEV} \
 "
 
-BUNDLE_CONTENTS[world] = " \
-    ${BUNDLE_CONTENTS_WORLD} \
-"
-
-# meta-swupd will switch from mapping "world-dev" to "world" +
-# ptest-pkgs. Instead it will expect us to provide the following
-# two variables. Already do that now to ease the transition:
 BUNDLE_CONTENTS[world-dev] = " \
     ${BUNDLE_CONTENTS_WORLD} \
 "

--- a/meta-ostro/recipes-image/images/ostro-image-swupd.bb
+++ b/meta-ostro/recipes-image/images/ostro-image-swupd.bb
@@ -26,6 +26,11 @@ OSTRO_IMAGE_EXTRA_FEATURES += "swupd"
 #
 # Keeping the number of bundles as low as possible is good for build
 # performance, too.
+#
+# Beware that removing bundles (and thus renaming) is currently
+# not supported by swupd client. When the need arises, the old
+# bundle has to be kept with some minimal content (see also
+# https://bugzilla.yoctoproject.org/show_bug.cgi?id=9493).
 SWUPD_BUNDLES ?= " \
     world-dev \
 "


### PR DESCRIPTION
Adds ptest packages to ostro-image-swupd-dev, as discussed with QA.
@testkit please review

The SERIAL_CONSOLES fix is necessary to re-enable running of tests on
qemu. The dangling symlink was found while experimenting with dbg-pkgs
in addition to ptest-pkgs (unfortunately that makes the image content
too large).

Both get added here in this PR to save test cycles.