### PR TITLE
ostro images: introduce minimal image without GPLv3

### DIFF
--- a/meta-ostro/conf/distro/include/ostroproject-ci.inc
+++ b/meta-ostro/conf/distro/include/ostroproject-ci.inc
@@ -12,8 +12,20 @@
 # Generate summary statistics
 INHERIT += "buildstats-summary"
 
-# Enable CVE and other secutiry checks
+# Enable CVE and other security checks.
 INHERIT += "isafw"
+
+# Most of the images are expected to contain GPLv3
+# components. Therefore we only enable the license check for those
+# which must not have them (whitelisting), instead of excluding images
+# from the check (blacklisting).
+ISAFW_LA_PLUGIN_IMAGE_WHITELIST = "ostro-image-minimal ostro-initramfs"
+
+# ostro-image-minimal is only getting built below as proof that an Ostro OS root
+# filesystem is possible without depending on GPLv3 components. The actual
+# image files are not needed for that.
+IMAGE_FSTYPES_pn-ostro-image-minimal = ""
+OSTRO_VM_IMAGE_TYPES_pn-ostro-image-minimal = ""
 
 # Enable extended buildhistory:
 INHERIT += "buildhistory"
@@ -45,7 +57,7 @@ OSTRO_VM_IMAGE_TYPES = "dsk.xz dsk.zip dsk.ova dsk.bmap dsk.xz.sha256sum"
 # Any other symbols would be skipped in parser.
 #
 # Following targets would be used to perform default build task:
-OSTROPROJECT_CI_BUILD_TARGETS="ostro-image-noswupd ostro-image-swupd ostro-image-swupd-dev"
+OSTROPROJECT_CI_BUILD_TARGETS="ostro-image-noswupd ostro-image-swupd ostro-image-swupd-dev ostro-image-minimal"
 # Following targets would be executed with do_populate_sdk task
 OSTROPROJECT_CI_SDK_TARGETS=""
 # Following targets would be executed with do_populate_sdk_ext task.

--- a/meta-ostro/recipes-image/images/ostro-image-minimal.bb
+++ b/meta-ostro/recipes-image/images/ostro-image-minimal.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Ostro base image."
+DESCRIPTION = "Ostro image for local builds with swupd disabled and no optional components whatsoever. The expected usage is to copy this recipe into a custom layer under a different name and then modifying it there to define the image for an Ostro OS based product."
+
+# In normal images without swupd it is possible to set per-image
+# variables for a specific image recipe using the the _pn-<image name>
+# notation.  However, that stops working once the swupd feature gets
+# enabled (because that internally relies on virtual images under
+# different names), so the recommended approach is to have per-recipe
+# variables (like OSTRO_IMAGE_MINIMAL_EXTRA_FEATURES) and customize
+# those outside the recipe.
+#
+# When copying the recipe, change the OSTRO_IMAGE_MINIMAL prefix
+# so that it matches the renamed recipe.
+OSTRO_IMAGE_MINIMAL_EXTRA_FEATURES ?= ""
+OSTRO_IMAGE_MINIMAL_EXTRA_INSTALL ?= ""
+OSTRO_IMAGE_EXTRA_FEATURES += "${OSTRO_IMAGE_MINIMAL_EXTRA_FEATURES}"
+OSTRO_IMAGE_EXTRA_INSTALL += "${OSTRO_IMAGE_MINIMAL_EXTRA_INSTALL}"
+
+inherit ostro-image

--- a/meta-ostro/recipes-image/images/ostro-image-noswupd.bb
+++ b/meta-ostro/recipes-image/images/ostro-image-noswupd.bb
@@ -1,20 +1,22 @@
 SUMMARY = "Ostro image for local builds with swupd disabled."
+DESCRIPTION = "Ostro image for local builds with swupd disabled. The default content matches the one from ostro-image-swupd. This is the recommended image when testing whether Ostro OS works on a device, because it builds faster than ostro-image-swupd and contains some useful systemd debugging tools for interactive use and, last but not least, an SSH server."
 
-# Image configuration cannot always be done using the _pn-ostro-image
-# notation, because then the configuration of the base image and
-# potential virtual images created from it would be different.
-#
-# Instead extend these variables. We cannot just use OSTRO_IMAGE_EXTRA_FEATURES
-# and OSTRO_IMAGE_EXTRA_INSTALL because those affect all images based
-# on ostro-image.bbclass.
+# In normal images without swupd it is possible to set per-image
+# variables for a specific image recipe using the the _pn-<image name>
+# notation.  However, that stops working once the swupd feature gets
+# enabled (because that internally relies on virtual images under
+# different names), so the recommended approach is to have per-recipe
+# variables (like OSTRO_IMAGE_NOSWUPD_EXTRA_FEATURES) and customize
+# those outside the recipe:
 OSTRO_IMAGE_NOSWUPD_EXTRA_FEATURES ?= "${OSTRO_IMAGE_FEATURES_REFERENCE}"
 OSTRO_IMAGE_NOSWUPD_EXTRA_INSTALL ?= "${OSTRO_IMAGE_INSTALL_REFERENCE}"
 OSTRO_IMAGE_EXTRA_FEATURES += "${OSTRO_IMAGE_NOSWUPD_EXTRA_FEATURES}"
 OSTRO_IMAGE_EXTRA_INSTALL += "${OSTRO_IMAGE_NOSWUPD_EXTRA_INSTALL}"
 
 # If the default "ostro-image-noswupd" name is
-# undesirable, write a custom image recipe similar to this one here
-# or customize the image file names.
+# undesirable, write a custom image recipe similar to this one here (although
+# ostro-image-minimal.bb might be a better starting point), or customize the
+# image file names when continuing to use ostro-image-noswupd.bb.
 #
 # Example for customization in local.conf when building ostro-image-noswupd.bb:
 # IMAGE_BASENAME_pn-ostro-image-noswupd = "my-ostro-image-reference"


### PR DESCRIPTION
The minimal image is already useful without GPLv3, although achieving that goal at the same time would be nice.
