### PR TITLE
image-dsk.bbclass: Revert back to old network interface mode

### DIFF
--- a/meta-ostro/classes/image-dsk.bbclass
+++ b/meta-ostro/classes/image-dsk.bbclass
@@ -67,9 +67,6 @@ create_ova() {
   STORAGE_DEVICE="0"
   STORAGE_DEVICE_TYPE="hdd"
 
-  # Network adapter mode
-  NIC_MODE="bridged"
-
   RAW_IMAGE="${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.dsk"
   VIRTUALBOX_IMAGE="${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.vmdk"
   VIRTUALBOX_EXECUTABLE="${STAGING_BINDIR_NATIVE}/VBoxManage"
@@ -98,9 +95,6 @@ create_ova() {
 
   # attach the .vmdk image as hard drive
   ${VIRTUALBOX_EXECUTABLE} storageattach ${VM_NAME} --storagectl ${STORAGE_NAME} --medium ${VIRTUALBOX_IMAGE} --port ${STORAGE_PORT} --device ${STORAGE_DEVICE} --type ${STORAGE_DEVICE_TYPE}
-
-  # Set the network adapter mode
-  ${VIRTUALBOX_EXECUTABLE} modifyvm ${VM_NAME} --nic1 ${NIC_MODE}
 
   # export the image
   ${VIRTUALBOX_EXECUTABLE} export ${VM_NAME} --output ${DEPLOY_DIR_IMAGE}/${APPLIANCE_NAME} --ovf20


### PR DESCRIPTION
When attempting to launch .ova that is set into bridged mode, it fails
with an error message. While quickly toggling the mode to nat and then
back to bridged fixes the issue, it still looks bad. As a short term
solution the interface is reverted back to NAT mode until I have time to
investigate what the root cause is.

Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>