### PR TITLE
openjdk/jre-8: ignore warnings about deprecated functions

### DIFF
--- a/meta-ostro/fixes/meta-java/recipes-core/openjdk/openjdk-8_%.bbappend
+++ b/meta-ostro/fixes/meta-java/recipes-core/openjdk/openjdk-8_%.bbappend
@@ -1,0 +1,5 @@
+# 'int readdir_r(DIR*, dirent*, dirent**)' is deprecated
+#
+# Reported to meta-java maintainers via the openembedded-devel
+# mailing list as "[meta-java] openjdk/jre-8: readdir_r deprecated".
+CFLAGS_append = "-Wno-error=deprecated-declarations"

--- a/meta-ostro/fixes/meta-java/recipes-core/openjdk/openjre-8_%.bbappend
+++ b/meta-ostro/fixes/meta-java/recipes-core/openjdk/openjre-8_%.bbappend
@@ -1,0 +1,1 @@
+openjdk-8_%.bbappend


### PR DESCRIPTION
readdir_r() recently got marked as deprecated, which causes builds
against OE-core master to fail. Work around it until meta-java
maintainers (notified) come up with something better.

This PR blocks further updates of OE-core in ostro-os (like
https://github.com/ostroproject/ostro-os/pull/100).