### PR TITLE
ostro.conf: exclude gsignond from world build

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -485,3 +485,11 @@ EXCLUDE_FROM_WORLD_pn-swupd-server = "1"
 # soletta-dev-app breaks builds in CI due to npm install and network
 # problems with it. Temporarily skip the build.
 EXCLUDE_FROM_WORLD_pn-soletta-dev-app = "1"
+
+# The plugin fails to compile against glibc in OE-core master:
+# error: 'soup_session_async_new_with_options' is deprecated: Use 'soup_session_new' instead [-Werror=deprecated-declarations]
+# We do not need gsignond yet, so disable building it unless someone explicitly asks for it.
+EXCLUDE_FROM_WORLD_pn-gsignond-plugin-oauth = "1"
+# And gsignond itself simply is not needed yet, so also disable the rest.
+EXCLUDE_FROM_WORLD_pn-gsignond = "1"
+EXCLUDE_FROM_WORLD_pn-gsignond-plugin-sasl = "1"


### PR DESCRIPTION
Building the eSDK indirectly builds gsignond and its plugins, which
fails when using latest libsoup from OE-core master:

../../git/src/gsignond-oauth-plugin.c: In function 'gsignond_oauth_plugin_init':
../../git/src/gsignond-oauth-plugin.c:540:5: error: 'soup_session_async_new_with_options' is deprecated: Use 'soup_session_new' instead [-Werror=deprecated-declarations]

This blocks https://github.com/ostroproject/ostro-os/pull/100, for example in 
https://ostroproject.org/jenkins/job/build_beaglebone/1613/console

@kad okay to merge without testing? Running a build test would not tell us
much when done with current ostro-os master.

[skip ci]