### PR TITLE
openjdk-8_%.bbappend: Add space in _append

### DIFF
--- a/meta-ostro/fixes/meta-java/recipes-core/openjdk/openjdk-8_%.bbappend
+++ b/meta-ostro/fixes/meta-java/recipes-core/openjdk/openjdk-8_%.bbappend
@@ -2,4 +2,4 @@
 #
 # Reported to meta-java maintainers via the openembedded-devel
 # mailing list as "[meta-java] openjdk/jre-8: readdir_r deprecated".
-CFLAGS_append = "-Wno-error=deprecated-declarations"
+CFLAGS_append = " -Wno-error=deprecated-declarations"


### PR DESCRIPTION
A space is missing in the CFLAGS_append, which can cause issues with GCC
flags.

Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>