### PR TITLE
Add groupcheck to Ostro OS.

### DIFF
--- a/meta-ostro/recipes-security/groupcheck-settings-default/groupcheck-settings-default_0.1.bb
+++ b/meta-ostro/recipes-security/groupcheck-settings-default/groupcheck-settings-default_0.1.bb
@@ -1,0 +1,28 @@
+# Copyright (C) 2016 Intel.
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Default groupcheck policy settings."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://default-groupcheck.policy \
+"
+
+inherit update-alternatives
+
+# use update-alternatives for letting several rulesets to be installed
+# to the same sysroot
+ALTERNATIVE_${PN} += "groupcheck.policy"
+ALTERNATIVE_LINK_NAME[groupcheck.policy] = "${datadir}/defaults/etc/groupcheck.policy"
+ALTERNATIVE_TARGET[groupcheck.policy] = "${datadir}/defaults/etc/default-groupcheck.policy"
+
+# update-alternatives does not add the generated files automatically to
+# FILES_${PN}
+
+FILES_${PN} += "${datadir}/defaults/etc/"
+
+do_install() {
+    install -d ${D}${datadir}/defaults/etc
+    install -m 0644 ${WORKDIR}/default-groupcheck.policy ${D}${datadir}/defaults/etc/default-groupcheck.policy
+}

--- a/meta-ostro/recipes-security/groupcheck/groupcheck_git.bb
+++ b/meta-ostro/recipes-security/groupcheck/groupcheck_git.bb
@@ -1,0 +1,35 @@
+# Copyright (C) 2016 Intel Corporation.
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Groupcheck -- a minimal polkit replacement"
+HOMEPAGE = "http://github.com/ostroproject/groupcheck"
+LICENSE = "LGPL2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
+
+SRC_URI = "git://github.com/ostroproject/groupcheck.git;protocol=git;rev=662f08b205f8d1783edbe07faa4d49fe5e795523"
+SRCREV = "662f08b205f8d1783edbe07faa4d49fe5e795523"
+
+DEPENDS = "systemd"
+
+S = "${WORKDIR}/git"
+
+inherit autotools systemd pkgconfig
+
+# Depend on a policy ruleset. If no ruleset is specified then use the
+# default configuration.
+VIRTUAL-RUNTIME_groupcheck-settings ?= "groupcheck-settings-default"
+RDEPENDS_${PN} += "${VIRTUAL-RUNTIME_groupcheck-settings}"
+
+do_install_append() {
+    install -d ${D}${systemd_unitdir}/system
+    install -d ${D}${sysconfdir}/dbus-1/system.d
+    install -d ${D}${libdir}/sysusers.d
+
+    install -m 0644 ${S}/groupcheck.service ${D}${systemd_unitdir}/system/
+    install -m 0644 ${S}/org.freedesktop.PolicyKit1.conf ${D}${sysconfdir}/dbus-1/system.d/
+    install -m 0644 ${S}/groupcheck.conf ${D}${libdir}/sysusers.d/
+}
+
+FILES_${PN} += "${libdir}/sysusers.d/groupcheck.conf"
+
+SYSTEMD_SERVICE_${PN} = "groupcheck.service"


### PR DESCRIPTION
Groupcheck is a drop-in polkit replacement for embedded systems. It only supports authentication by group membership. See https://github.com/ostroproject/groupcheck for details.

This PR adds groupcheck recipe and its default (empty) configuration. It also adds groupcheck to Ostro OS images.