### PR TITLE
Software Update: add QA test Bundles into dev image

### DIFF
--- a/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
+++ b/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
@@ -99,6 +99,9 @@ gobject-introspection@core
 gptfdisk@core
 grep@core
 gzip@core
+hello-bundle-a@iotqa
+hello-bundle-b@iotqa
+hello-bundle-s@iotqa
 htop@openembedded-layer
 i2c-edison-board@quark-bsp
 i2c-minnowmax-board@quark-bsp

--- a/meta-ostro/recipes-image/images/ostro-image-swupd.bb
+++ b/meta-ostro/recipes-image/images/ostro-image-swupd.bb
@@ -112,8 +112,7 @@ SWUPD_IMAGES ?= " \
     all \
 "
 
-# In practice the same as "all" at the moment, but conceptually different
-# and thus defined separately.
+#add qa-bundle-a in swupd-dev image for QA testing.
 SWUPD_IMAGES[dev] = " \
     world-dev \
     qa-bundle-a \

--- a/meta-ostro/recipes-image/images/ostro-image-swupd.bb
+++ b/meta-ostro/recipes-image/images/ostro-image-swupd.bb
@@ -33,6 +33,8 @@ OSTRO_IMAGE_EXTRA_FEATURES += "swupd"
 # https://bugzilla.yoctoproject.org/show_bug.cgi?id=9493).
 SWUPD_BUNDLES ?= " \
     world-dev \
+    qa-bundle-a \
+    qa-bundle-b \
 "
 
 # os-core defined via additional image features maintained in ostro-image.bbclass.
@@ -76,6 +78,14 @@ BUNDLE_FEATURES[world-dev] = " \
     dev-pkgs \
     ptest-pkgs \
 "
+BUNDLE_CONTENTS[qa-bundle-a] = " \
+    hello-bundle-a \
+    hello-bundle-s \
+"
+BUNDLE_CONTENTS[qa-bundle-b] = " \
+    hello-bundle-b \
+    hello-bundle-s \
+"
 
 # When swupd bundles are enabled, choose explicitly which images
 # are created. The base image will only have the core-os bundle.
@@ -105,7 +115,8 @@ SWUPD_IMAGES ?= " \
 # In practice the same as "all" at the moment, but conceptually different
 # and thus defined separately.
 SWUPD_IMAGES[dev] = " \
-    ${SWUPD_BUNDLES} \
+    world-dev \
+    qa-bundle-a \
 "
 SWUPD_IMAGES[all] = " \
     ${SWUPD_BUNDLES} \


### PR DESCRIPTION
Add 2 QA test bundles into dev image to cover verification of shared contents between bundles.
qa-bundle-a: contains 2 recipes, hello-bundle-a and hello-bundle-s(shared).
qa-bundle-b: contains 2 recipes, hello-bundle-b and hello-bundle-s(shared).

[Relates-to]: IOTOS-1290

Signed-off-by: yma11 <yan.ma@intel.com>