### PR TITLE
stay on gcc 5.3

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -236,6 +236,13 @@ PREFERRED_PROVIDER_virtual/java-initial-native = "cacao-initial-native"
 PREFERRED_PROVIDER_virtual/java-native = "cacao-native"
 PREFERRED_PROVIDER_virtual/javac-native = "ecj-bootstrap-native"
 
+# OE-core recently switched to gcc 6.1 (OE-core commit c20d863da5700, see tcmode-default.inc).
+# However, that breaks compilation of iotivity 1.1.0 (IOTOS-1625, "call of overloaded 'abs(double)' is ambiguous")
+# and linux-yocto-edison 3.10.98 (IOTOS-1626, "fatal error: linux/compiler-gcc6.h: No such file or directory").
+#
+# Until these issues are fixed, we need to stay on gcc 5.3, the previous default.
+GCCVERSION ?= "5.3%"
+
 # Ostro OS removes certain packages from images because the components are known
 # to have compile issues and/or are not supported. Can be modified in derived
 # distros or via local.conf.


### PR DESCRIPTION
Some of our components (iotivity, Edison kernel) do not compile with
gcc 6.1 yet. Until they do, we need to stay on gcc 5.3.

This commit was tested successfully with the latest upstream
components in https://github.com/ostroproject/ostro-os/pull/110

@kad: agreed to use this as a workaround for the time being? Bugs against
iotivity and the kernel are filed, see comment in ostro.conf.