### PR TITLE
soletta_%.bbappend: adapt to OE-core packaging change

### DIFF
--- a/meta-ostro/recipes-soletta/soletta/soletta_%.bbappend
+++ b/meta-ostro/recipes-soletta/soletta/soletta_%.bbappend
@@ -4,6 +4,10 @@ DEPENDS_append = " systemd"
 
 SRC_URI += " file://config"
 
+# Restore "no strip, no debug split" behavior after
+# recent OE-core packaging change. See https://github.com/solettaproject/meta-soletta/issues/88
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
 INSANE_SKIP_${PN}-dev += "dev-elf"
 
 do_configure_prepend() {


### PR DESCRIPTION
This fixes the build error in our current CI PR (https://github.com/ostroproject/ostro-os/pull/116).

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>