### PR TITLE
openssl_%.bbappend: remove .a symlink workaround

### DIFF
--- a/meta-ostro-fixes/meta-fixes/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/meta-ostro-fixes/meta-fixes/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,6 +1,0 @@
-# Upstream-Status: Submitted [https://bugzilla.yoctoproject.org/show_bug.cgi?id=9523]
-
-do_install_ptest_append () {
-    # openssl.inc links to /lib/libcrypto.a instead of the correct /usr/lib/libcrypto.a
-    ln -sf ${libdir}/libcrypto.a ${D}${PTEST_PATH}
-}


### PR DESCRIPTION
Upstream has fixed the problem (YOCTO #9523) in OE-core rev
3d6884a9. Besides, the fix was added in the wrong place and only
needed when enabling full symlink checking as part of the stateless
work.

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>