### PR TITLE
classes: Python3 compatibility

### DIFF
--- a/meta-ostro/classes/stateless.bbclass
+++ b/meta-ostro/classes/stateless.bbclass
@@ -114,7 +114,7 @@ def stateless_mangle(d, root, docdir, stateless_mv, stateless_rm, dirwhitelist, 
         bb.note('stateless: removing dir %s' % path)
         try:
             os.rmdir(path)
-        except OSError, ex:
+        except OSError as ex:
             bb.note('stateless: removing dir failed: %s' % ex)
             if ex.errno != errno.ENOTEMPTY:
                  raise

--- a/meta-ostro/classes/supported-recipes.bbclass
+++ b/meta-ostro/classes/supported-recipes.bbclass
@@ -113,7 +113,7 @@ def load_supported_recipes(d):
                 try:
                     # must match entire string, hence the '$'
                     return (re.compile(regex + '$'), regex)
-                except Exception, ex:
+                except Exception as ex:
                     raise RuntimeError("%s.%d: parsing '%s' as regular expression failed: %s" % (
                         filename,
                         linenumber,
@@ -171,7 +171,7 @@ def load_supported_recipes(d):
                         supported_recipes.append(SupportedRecipe(line.strip(), file, linenumber))
                     linenumber += 1
             files.append(file)
-        except OSError, ex:
+        except OSError as ex:
             bb.fatal('Could not read SUPPORTED_RECIPES = %s: %s' % (supported_file, str(ex)))
 
     return (supported_recipes, files)


### PR DESCRIPTION
The old "except Foo, ex" no longer works once bitbake migrates to
Python3.

This is required (but not sufficient) for solving the Python3-related
problems in https://github.com/ostroproject/ostro-os/pull/116

We also need some of the already pending meta-openembedded patches.