### PR TITLE
Documentation for deploying to internal storage.

### DIFF
--- a/doc/howtos/booting-and-installation.rst
+++ b/doc/howtos/booting-and-installation.rst
@@ -127,6 +127,62 @@ includes a checksum verification, you can also use the traditional :command:`dd`
 Unplug the removable media from your development system and you're ready to plug
 it into your target system.
 
+Installing to internal media on generic x86 EFI platforms
+=========================================================
+
+This section applies to those cases where the device is x86 compatible (ex: Gigabyte NUC).
+The simpler way is to follow these steps:
+
+#. Create a Bootable Media using both an image that is compatible with the device
+   and a supported removable media (SD card or USB stick).
+#. Boot the device with the removable media created at the previous step.
+#. Once the device is booted, identify the booted media, for example by executing::
+
+      # mount
+
+   and locating in its output which partition is mounted ``on /``.
+   This will be a partition belonging to the source block device.
+   Example::
+
+      /dev/sdb3 on / type ext4 (rw,realtime,i_version,data=ordered)
+
+   Shows that the root partition is on ``/dev/sdb3``, therefore the source block device will
+   be ``/dev/sdb``.
+#. Identify the block device representing the internal storage.
+   This part is really specific to each platfrom: typically the internal storage is
+   associated to ``/dev/sda`` for hard disks and SSD units and to ``/dev/mmcblk0`` for eMMC
+   devices, but it should be confirmed against the board manual.
+#. Issue the ``dd`` command with the parameters identified in the last 2 points.
+   Example with internal storage as eMMC on ``/dev/mmcblk0`` and removable media as USB stick
+   on ``/dev/sda``::
+
+      # dd if=/dev/sda of=/dev/mmcblk0 bs=5M && sync
+
+#. When the command has terminated, poweroff the device, extract the removable media
+   and power it back on. This should be sufficient to have the unit now using the internal
+   storage.
+
+
+Removing Ostro OS from internal media
+=====================================
+   Ostro OS uses GID for identifying the rootfs and the GID is kept consistent across all the
+   images produced. This means that trying to boot a system with 2 Ostro OS images available at the
+   same time will likely produce unwanted/undetermined results.
+   Before trying again to boot from a removable media, the internal media should be wiped.
+   To achieve this:
+#. Boot from the internal media.
+#. Identify the root block device containing the rootfs partition.
+#. Wipe a sufficient part of that block device to make it unbootable.
+   In practice it means wiping the primary GPT and at least the beginngin of both partitions that
+   might be EFI-bootable. In an unmodified Ostro disk layout, this means the first 2 partitions,
+   which are 15MB each. 20 MB would be sufficient to cover the beginning of the disk, the first
+   partition and the beginning of the second. 30MB will wipe even the beginning of the rootfs.
+   Example with rootfs on ``/dev/sda3``::
+
+      # dd if=/dev/zero of=/dev/sda bs=5M count=6 && sync
+
+#. Poweroff the device (ignore possible ext4 error messages).
+#. Insert the removable media with the new Ostro OS image and power on.
 
 MinnowBoard Turbot - a MinnowBoard MAX Compatible
 =================================================

--- a/meta-ostro/classes/buildhistory-extra.bbclass
+++ b/meta-ostro/classes/buildhistory-extra.bbclass
@@ -120,21 +120,33 @@ python buildhistory_extra_emit_kernelconfig() {
 }
 
 buildhistory_get_image_installed_append() {
-	# Create a file mapping installed packages to recipes
-	printf "" > ${BUILDHISTORY_DIR_IMAGE}/installed-package-recipes.txt
-	cat ${IMAGE_MANIFEST} | while read pkg pkgarch version
-	do
-		if [ -n "$pkg" ] ; then
-			recipe=`oe-pkgdata-util -p ${PKGDATA_DIR} lookup-recipe $pkg`
-			pkge=`oe-pkgdata-util -p ${PKGDATA_DIR} read-value PKGE $pkg`
-			if [ "$pkge" != "" ] ; then
-				pkge="$pkge-"
-			fi
-			pkgr=`oe-pkgdata-util -p ${PKGDATA_DIR} read-value PKGR $pkg`
-			if [ "$pkgr" != "" ] ; then
-				pkgr="-$pkgr"
-			fi
-			echo "$pkg $version $pkge$version$pkgr $recipe" >> ${BUILDHISTORY_DIR_IMAGE}/installed-package-recipes.txt
-		fi
-	done
+    # Create a file mapping installed packages to recipes
+    printf "" > ${BUILDHISTORY_DIR_IMAGE}/installed-package-recipes.txt
+    export PSEUDO_UNLOAD=1
+    cat ${IMAGE_MANIFEST} | while read pkg pkgarch version
+    do
+        if [ -n "$pkg" ] ; then
+            pkgv=`oe-pkgdata-util -p ${PKGDATA_DIR} read-value PKGV $pkg`
+            pkge=`oe-pkgdata-util -p ${PKGDATA_DIR} read-value PKGE $pkg`
+            if [ "${pkge}" != "" ] ; then
+                pkge="${pkge}:"
+            fi
+            pkgr=`oe-pkgdata-util -p ${PKGDATA_DIR} read-value PKGR $pkg`
+            if [ "${pkgr}" != "" ] ; then
+                pkgr="-${pkgr}"
+            fi
+            recipe=`oe-pkgdata-util -p ${PKGDATA_DIR} read-value PN $pkg`
+            recipev=`oe-pkgdata-util -p ${PKGDATA_DIR} read-value PV $pkg`
+            recipee=`oe-pkgdata-util -p ${PKGDATA_DIR} read-value PE $pkg`
+            if [ "${recipee}" != "" ]; then
+                recipee="${recipee}:"
+            fi
+            reciper=`oe-pkgdata-util -p ${PKGDATA_DIR} read-value PR $pkg`
+            if [ "${reciper}" != "" ]; then
+                reciper="-${reciper}"
+            fi
+            echo "$pkg $version ${pkge}${pkgv}${pkgr} $recipe ${recipee}${recipev}${reciper}" >> ${BUILDHISTORY_DIR_IMAGE}/installed-package-recipes.txt
+        fi
+    done
+    unset PSEUDO_UNLOAD
 }


### PR DESCRIPTION
This section shows how to deploy an Ostro OS image
to the internal storage that might be available on certain
platforms.

Signed-off-by: Igor Stoppa <igor.stoppa@intel.com>