### PR TITLE
ostro os: remove questionable zip and iotop

### DIFF
--- a/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
+++ b/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
@@ -119,7 +119,6 @@ iot-rest-api-server@iotweb
 iotivity-node@iotweb
 iotivity-simple-client@oic
 iotivity@oic
-iotop@openembedded-layer
 iproute2@core
 iptables-settings-default@ostro
 iptables@core
@@ -231,5 +230,4 @@ volatile-binds@core
 wget@core
 wpa-supplicant@core
 xz@core
-zip@core
 zlib@core

--- a/meta-ostro/recipes-core/packagegroups/packagegroup-tools-interactive.bb
+++ b/meta-ostro/recipes-core/packagegroups/packagegroup-tools-interactive.bb
@@ -17,7 +17,6 @@ RDEPENDS_${PN} = " \
     gzip \
     htop \
     iftop \
-    iotop \
     iputils-arping \
     iputils-clockdiff \
     iputils-ping \
@@ -32,5 +31,4 @@ RDEPENDS_${PN} = " \
     usbutils \
     vim \
     wget \
-    zip \
 "


### PR DESCRIPTION
Internal review raised some concerns about the upstream maintenance of
these components. Because there are no hard requirements for them and
there are alternatives for interactive use (tar is better for archival
than zip, and atop can show similar information as iotop), the easiest
solution is to remove the components.

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>