### PR TITLE
prepare for Python3 migration

### DIFF
--- a/meta-ostro/classes/stateless.bbclass
+++ b/meta-ostro/classes/stateless.bbclass
@@ -157,7 +157,7 @@ python stateless_check() {
     whitelist = (d.getVar('STATELESS_ETC_WHITELIST', True) or '').split()
     import os
     sane = True
-    for pkg, files in pkgfiles.iteritems():
+    for pkg, files in pkgfiles.items():
         pkgdir = os.path.join(d.getVar('PKGDEST', True), pkg)
         for file in files:
             targetfile = file[len(pkgdir):]

--- a/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
+++ b/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
@@ -176,7 +176,6 @@ nettle@core
 nodejs@iotweb
 oe-swupd-helpers@meta-swupd
 openjdk-8@meta-java
-openjre-8@meta-java
 openssh@core
 openssl@core
 opkg-utils@core

--- a/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
+++ b/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
@@ -192,6 +192,10 @@ ptest-runner@core
 python-dbus@core
 python-pygobject@core
 python-setuptools@core
+python3-dbus@core
+python3-pygobject@core
+python3-setuptools@core
+python3@core
 python@core
 read-map@iotqa
 readline@core

--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -68,7 +68,7 @@ SIGGEN_LOCKEDSIGS_TASKSIG_CHECK = "none"
 # For more predictable results is possible to set OS_RELEASE manually,
 # either in local.conf or in the environment like this:
 #   BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE OS_VERSION" OS_VERSION=110 bitbake ...
-OS_VERSION ?= "${@ str(((int('${DATETIME}') - 20160000000000) / 100) * 10) }"
+OS_VERSION ?= "${@ str(int('${DATETIME}') - 20160000000000)[:-2] + '0'}"
 OS_VERSION[vardepsexclude] += "DATETIME"
 
 # Ostro OS tries to build minimal images and thus prefers Busybox or

--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -236,6 +236,15 @@ PREFERRED_PROVIDER_virtual/java-initial-native = "cacao-initial-native"
 PREFERRED_PROVIDER_virtual/java-native = "cacao-native"
 PREFERRED_PROVIDER_virtual/javac-native = "ecj-bootstrap-native"
 
+# Java runtime: used by packagegroup-java-jdk.bb and packages which
+# RDEPEND on Java.
+#
+# Must use openjdk-8 because Ostro OS is meant to support on-device
+# compilation of Java programs, and we don't want to end up
+# compiling and installing both jre and jdk (they are separate
+# packages which share no files).
+PREFERRED_RPROVIDER_java2-runtime = "openjdk-8"
+
 # OE-core recently switched to gcc 6.1 (OE-core commit c20d863da5700, see tcmode-default.inc).
 # However, that breaks compilation of iotivity 1.1.0 (IOTOS-1625, "call of overloaded 'abs(double)' is ambiguous")
 # and linux-yocto-edison 3.10.98 (IOTOS-1626, "fatal error: linux/compiler-gcc6.h: No such file or directory").

--- a/meta-ostro/recipes-core/packagegroups/packagegroup-java-jdk.bb
+++ b/meta-ostro/recipes-core/packagegroups/packagegroup-java-jdk.bb
@@ -3,6 +3,9 @@ LICENSE = "MIT"
 
 inherit packagegroup
 
+# To avoid installing two different Java runtimes, we use the same one here
+# that other packages already depend on via RDEPENDS, and in ostro.conf
+# configure that to be what we want to have in Ostro OS.
 RDEPENDS_${PN} = " \
-    openjdk-8 \
+    ${PREFERRED_RPROVIDER_java2-runtime} \
 "


### PR DESCRIPTION
This fixes build issues and allows Python3 in the target images.

Blocks https://github.com/ostroproject/ostro-os/pull/116 but is safe to merge already now.