### PR TITLE
image-dsk.bbclass: Replace 'exit 0' with 'return'

### DIFF
--- a/meta-ostro/classes/image-dsk.bbclass
+++ b/meta-ostro/classes/image-dsk.bbclass
@@ -42,7 +42,7 @@ IMAGE_NAME_SUFFIX = ""
 create_ova() {
 
   if [ "x${MACHINE}x" != "xintel-corei7-64x" ]; then
-    exit 0
+    return
   fi
 
   # 64 bit linux with sata bus


### PR DESCRIPTION
Using 'exit 0' prevents any following code from being run. This means
that the unnecessary .dsk file is not being deleted and that .bmap files
are not being generated.

Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>