### PR TITLE
java: Move java behind DISTRO_FEATURES feature

### DIFF
--- a/meta-ostro/classes/ostro-image.bbclass
+++ b/meta-ostro/classes/ostro-image.bbclass
@@ -40,7 +40,6 @@ OSTRO_IMAGE_PKG_FEATURES = " \
     connectivity \
     devkit \
     iotivity \
-    java-jdk \
     nodejs-runtime \
     nodejs-runtime-tools \
     python-runtime \
@@ -50,6 +49,10 @@ OSTRO_IMAGE_PKG_FEATURES = " \
     tools-develop \
     tools-interactive \
 "
+
+OSTRO_IMAGE_PKG_FEATURES += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'java', 'java-jdk', '', d)} \
+    "
 
 # Here is the complete list of image features, also including
 # those that modify the image configuration.

--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -129,6 +129,10 @@ OSTRO_DEFAULT_DISTRO_FEATURES += "ima"
 # then that is a bug in the recipe.
 OSTRO_DEFAULT_DISTRO_FEATURES += "ptest"
 
+# enable Java as distro feature - this adds the java-jdk package group into
+# images and enables Java bindings and other Java dependent features
+OSTRO_DEFAULT_DISTRO_FEATURES += "java"
+
 # Remove currently unsupported distro features from global defaults
 DISTRO_FEATURES_DEFAULT_remove = "x11 3g"
 

--- a/meta-ostro/recipes-devtools/mraa/mraa_%.bbappend
+++ b/meta-ostro/recipes-devtools/mraa/mraa_%.bbappend
@@ -1,0 +1,2 @@
+# if DISTRO_FEATURES do not have Java enabled, remove Java from the bindings list
+BINDINGS_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'java', '', 'java', d)}"

--- a/meta-ostro/recipes-devtools/upm/upm_%.bbappend
+++ b/meta-ostro/recipes-devtools/upm/upm_%.bbappend
@@ -1,0 +1,2 @@
+# if DISTRO_FEATURES do not have Java enabled, remove java from the bindings list
+BINDINGS_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'java', '', 'java', d)}"


### PR DESCRIPTION
Java is a fairly heavyweight package, and it is likely that at least
some users would like to disable it altogether. Currently both mraa and
upm unconditionally depend on Java, which means it will get included in
the image even if the java-jdk packagegroup is not included.

A new distro feature, java, is introduced to gate both the mraa\upm and
java package group dependencies, so that Java can be easily disabled.

Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>