### PR TITLE
ostro-image.bbclass: add valgrind to debugging tools

### DIFF
--- a/meta-ostro/classes/ostro-image.bbclass
+++ b/meta-ostro/classes/ostro-image.bbclass
@@ -200,6 +200,13 @@ FEATURE_PACKAGES_tools-develop = "packagegroup-core-buildessential git"
 # priorities.
 FEATURE_PACKAGES_tools-interactive = "packagegroup-tools-interactive bash"
 
+# OE-core treats "valgrind" as part of tools-profile aka
+# packagegroup-core-tools-profile.bb. We do not enable that set of tools
+# in Ostro because not all of them work and/or make sense, but valgrind
+# makes sense, in particular for debugging, so we add it there.
+# All our platforms support it, so this can be unconditional.
+FEATURE_PACKAGES_tools-debug_append = " valgrind"
+
 # We could make bash the login shell for interactive accounts as shown
 # below, but that would have to be done also in the os-core and thus
 # tools-interactive would have to be set in all swupd images.


### PR DESCRIPTION
valgrind makes (more?) sense as a debugging tool than a profiling tool
(which is where it appears in OE-core), so let's add it to the
"tools-debug" image feature.

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>