### PR TITLE
ostro-image.bbclass: install mraa/upm bindings

### DIFF
--- a/meta-ostro/classes/ostro-image.bbclass
+++ b/meta-ostro/classes/ostro-image.bbclass
@@ -182,7 +182,10 @@ FEATURE_PACKAGES_can = "packagegroup-core-can"
 FEATURE_PACKAGES_ima = "packagegroup-ima-evm-utils"
 
 FEATURE_PACKAGES_iotivity = "packagegroup-iotivity"
-FEATURE_PACKAGES_devkit = "packagegroup-devkit"
+FEATURE_PACKAGES_devkit = "packagegroup-devkit \
+    ${@ bb.utils.contains('IMAGE_FEATURES', 'java-jdk', 'mraa-java upm-java', '', d)} \
+    ${@ bb.utils.contains('IMAGE_FEATURES', 'python-runtime', 'python-mraa', '', d)} \
+"
 
 FEATURE_PACKAGES_nodejs-runtime = "packagegroup-nodejs-runtime"
 FEATURE_PACKAGES_nodejs-runtime-tools = "packagegroup-nodejs-runtime-tools"


### PR DESCRIPTION
The Java and Python binding packages of mraa and upm were not
installed before because nothing depended on them. The two runtimes
can't depend on them because it is uncertain whether these optional
features are wanted, and the core devkit cannot depend on them because
it is uncertain whether the runtimes are wanted.

At the image level we can decide that based on the IMAGE_FEATURES.

Fixes: IOTOS-1680

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>