### PR TITLE
Enable frequently needed HTTP access components

### DIFF
--- a/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
+++ b/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
@@ -87,6 +87,7 @@ gdbm@core
 gettext@core
 git@core
 glib-2.0@core
+glib-networking@core
 glibc-locale@core
 glibc-mtrace@core
 glibc@core
@@ -148,6 +149,7 @@ libpcap@core
 libpcre@core
 libpng@core
 libsocketcan@openembedded-layer
+libsoup-2.4@core
 libtool@core
 liburcu@core
 libusb-compat@core


### PR DESCRIPTION
Enable glib-networking and libsoup recipes which are commonly needed for
various cloud access utilities.

Signed-off-by: Jussi Laako <jussi.laako@linux.intel.com>