### PR TITLE
meta-ostro: Don't enable disk monitoring via BB_DISKMON_DIRS in CI

### DIFF
--- a/meta-ostro/conf/distro/include/ostroproject-ci.inc
+++ b/meta-ostro/conf/distro/include/ostroproject-ci.inc
@@ -85,6 +85,10 @@ OSTROPROJECT_CI_TEST_RUNS="ostro-image-swupd-dev,iot-testsuite.tar.gz,iot-testfi
 # still needs to be determined.
 OS_VERSION ?= "${@ str(int('${BUILD_ID}'.split('-')[-1]) * 10) }"
 
+# Dont use disk space monitor in CI builds, to avoid frequent
+# space checks on (possibly remote, like NFS) volumes.
+BB_DISKMON_DIRS = ""
+
 #
 # Dymamic section.
 # Values are applied dynamically based on runtime config or builder host

--- a/meta-ostro/conf/local.conf.sample
+++ b/meta-ostro/conf/local.conf.sample
@@ -216,7 +216,7 @@ PATCHRESOLVE = "noop"
 # shutdown the build. If there is less that 100MB or 1K inodes, perform a hard abort
 # of the build. The reason for this is that running completely out of space can corrupt
 # files and damages the build in ways which may not be easily recoverable.
-BB_DISKMON_DIRS = "\
+BB_DISKMON_DIRS ?= "\
     STOPTASKS,${TMPDIR},1G,100K \
     STOPTASKS,${DL_DIR},1G,100K \
     STOPTASKS,${SSTATE_DIR},1G,100K \


### PR DESCRIPTION
Frequent disk cpace checks create massive amount of transactions
to single NFS server in CI environment, but CI servers disks
are not likely to get full in regular building, so lets avoid
DISKMON checks in CI builds.