### PR TITLE
ostro-image.bbclass: Add UPM & mraa nodejs bindings

### DIFF
--- a/meta-ostro/classes/ostro-image.bbclass
+++ b/meta-ostro/classes/ostro-image.bbclass
@@ -185,6 +185,7 @@ FEATURE_PACKAGES_iotivity = "packagegroup-iotivity"
 FEATURE_PACKAGES_devkit = "packagegroup-devkit \
     ${@ bb.utils.contains('IMAGE_FEATURES', 'java-jdk', 'mraa-java upm-java', '', d)} \
     ${@ bb.utils.contains('IMAGE_FEATURES', 'python-runtime', 'python-mraa', '', d)} \
+    ${@ bb.utils.contains('IMAGE_FEATURES', 'nodejs-runtime', 'node-mraa node-upm', '', d)} \
 "
 
 FEATURE_PACKAGES_nodejs-runtime = "packagegroup-nodejs-runtime"


### PR DESCRIPTION
Signed-off-by: Brendan Le Foll <brendan.le.foll@intel.com>

Removed python-upm because those bindings are currently disabled
in upm_0.7.0.bb.

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>

Replaces PR #225.

@arfoll okay to merge if it builds okay? Testing of PR #225 is still
running, but I expect it to fail due to the missing python-upm.

I created this PR here to get at least some of your changes merged soon.