### PR TITLE
packagegroup-devkit.bb: add mraa-utils to devkit packagegroup

### DIFF
--- a/meta-ostro/recipes-core/packagegroups/packagegroup-devkit.bb
+++ b/meta-ostro/recipes-core/packagegroups/packagegroup-devkit.bb
@@ -6,5 +6,6 @@ inherit packagegroup
 RDEPENDS_${PN} = " \
     linuxptp \
     mraa \
+    mraa-utils \
     upm \
 "


### PR DESCRIPTION
This requires https://github.com/ostroproject/meta-intel-iot-middleware/pull/10 before mraa-utils works correctly.