### PR TITLE
add bbappends for jdk and icedtea

### DIFF
--- a/meta-ostro-fixes/meta-fixes/recipes-devtools/icedtea/icedtea7-native_%.bbappend
+++ b/meta-ostro-fixes/meta-fixes/recipes-devtools/icedtea/icedtea7-native_%.bbappend
@@ -1,0 +1,7 @@
+
+EXTRA_OEMAKE_append = ' \
+    OE_CFLAGS="${CFLAGS}" \
+    OE_CPPFLAGS="${CPPFLAGS}" \
+    OE_CXXFLAGS="${CXXFLAGS}" \
+    OE_LDFLAGS="${LDFLAGS}" \
+'

--- a/meta-ostro-fixes/meta-fixes/recipes-devtools/openjdk/openjdk-8_%.bbappend
+++ b/meta-ostro-fixes/meta-fixes/recipes-devtools/openjdk/openjdk-8_%.bbappend
@@ -1,0 +1,7 @@
+
+EXTRA_OEMAKE_append = ' \
+    OE_CFLAGS="${CFLAGS}" \
+    OE_CPPFLAGS="${CPPFLAGS}" \
+    OE_CXXFLAGS="${CXXFLAGS}" \
+    OE_LDFLAGS="${LDFLAGS}" \
+'


### PR DESCRIPTION
This should fix the build issues with the latest meta-java