### PR TITLE
ostro-version.bbclass: introduce single OS_VERSION definition

### DIFF
--- a/meta-ostro/classes/ostro-version.bbclass
+++ b/meta-ostro/classes/ostro-version.bbclass
@@ -1,0 +1,57 @@
+# When building in a CI system with swupd enabled, OS_VERSION must be
+# set to a consistent value for all builds. See below
+# for an example how that works with Jenkins.
+#
+# In local builds, we only have ${DATETIME} as something that
+# increments automatically, but it is too large for an integer number
+# on 32 bit systems. Therefore we substract the 2016 as the initial
+# year in which Ostro OS started using swupd and ignore the
+# seconds.
+#
+# The default behavior is to not rebuild just because OS_VERSION
+# changed. If that is desired, include in local.conf:
+#   VERSION_ID = "${OS_VERSION}"
+# This will cause the os-release package to be rebuilt each time
+# OS_VERSION changes, and that in turn causes an image and bundle
+# rebuild.
+#
+# For more predictable results is possible to set OS_RELEASE manually,
+# either in local.conf or in the environment like this:
+#   BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE OS_VERSION" OS_VERSION=110 bitbake ...
+
+def ostro_get_os_version(d):
+    build_id_str = d.getVar('BUILD_ID', True) or ''
+    if build_id_str:
+        try:
+            build_id = int(build_id_str)
+        except ValueError:
+            # Assume that BUILD_ID is in CI's format, e.g. "2016-07-10_18-49-16-build-127".
+            # We cannot have the definition for OS_VERSION in ostroproject-ci.inc because
+            # the file is used also in eSDKs produced by CI where BUILD_ID is not set in
+            # the expected format.
+            #
+            # In the CI system, the integer OS version used for swupd is derived
+            # from the Jenkins build number part of the BUILD_ID. The conversion
+            # to int and back to string acts as sanity check that we really get a
+            # number out of the BUILD_ID.
+            #
+            # BUILD_ID is expected to have this format:
+            # BUILD_ID = "<parent-build-timestamp (of Jenkins top job)>" + "-build-" + "<jenkins-top-job-build-number>"
+            #
+            # We multiply it by ten, to ensure that the version space has some gap
+            # for minor updates. How to actually build minor updates with Jenkins
+            # still needs to be determined.
+            build_id = int(build_id_str.split('-')[-1]) * 10
+
+        # check if we have reached max value for 32-bit integer
+        if build_id > 2147483646:
+            bb.warn("The current value for BUILD_ID (%d) doesn't fit 32-bit integer: redefining..." % build_id)
+            return str(((int(d.getVar('DATETIME', True)) - 20160000000000) / 100) * 10)
+
+        return str(build_id)
+    else:
+        return str(((int(d.getVar('DATETIME', True)) - 20160000000000) / 100) * 10)
+
+ostro_get_os_version[vardepsexclude] += "DATETIME"
+
+OS_VERSION ?= "${@ostro_get_os_version(d)}"

--- a/meta-ostro/conf/distro/include/ostroproject-ci.inc
+++ b/meta-ostro/conf/distro/include/ostroproject-ci.inc
@@ -72,19 +72,6 @@ OSTROPROJECT_CI_TEST_EXPORT_TARGETS="ostro-image-swupd-dev"
 # <image_name>,<testsuite_name>,<testfiles_name>,$MACHINE
 OSTROPROJECT_CI_TEST_RUNS="ostro-image-swupd-dev,iot-testsuite.tar.gz,iot-testfiles.${MACHINE}.tar.gz,${MACHINE}"
 
-# In the CI system, the integer OS version used for swupd is derived
-# from the Jenkins build number part of the BUILD_ID. The conversion
-# to int and back to string acts as sanity check that we really get a
-# number out of the BUILD_ID.
-#
-# BUILD_ID is expected to have this format:
-# BUILD_ID = "<parent-build-timestamp (of Jenkins top job)>" + "-build-" + "<jenkins-top-job-build-number>"
-#
-# We multiply it by ten, to ensure that the version space has some gap
-# for minor updates. How to actually build minor updates with Jenkins
-# still needs to be determined.
-OS_VERSION ?= "${@ str(int('${BUILD_ID}'.split('-')[-1]) * 10) }"
-
 # Dont use disk space monitor in CI builds, to avoid frequent
 # space checks on (possibly remote, like NFS) volumes.
 BB_DISKMON_DIRS = ""

--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -48,28 +48,7 @@ SDK_LOCAL_CONF_BLACKLIST_append = " BB_NUMBER_PARSE_THREADS"
 # fixed, SSTATE checks need to be run in self-tests.
 SIGGEN_LOCKEDSIGS_TASKSIG_CHECK = "none"
 
-# When building in a CI system with swupd enabled, OS_VERSION must be
-# set to a consistent value for all builds. See ostroproject-ci.inc
-# for an example how that works with Jenkins.
-#
-# In local builds, we only have ${DATETIME} as something that
-# increments automatically, but it is too large for an integer number
-# on 32 bit systems. Therefore we substract the 2016 as the initial
-# year in which Ostro OS started using swupd and ignore the
-# seconds.
-#
-# The default behavior is to not rebuild just because OS_VERSION
-# changed. If that is desired, include in local.conf:
-#   VERSION_ID = "${OS_VERSION}"
-# This will cause the os-release package to be rebuilt each time
-# OS_VERSION changes, and that in turn causes an image and bundle
-# rebuild.
-#
-# For more predictable results is possible to set OS_RELEASE manually,
-# either in local.conf or in the environment like this:
-#   BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE OS_VERSION" OS_VERSION=110 bitbake ...
-OS_VERSION ?= "${@ str(int('${DATETIME}') - 20160000000000)[:-2] + '0'}"
-OS_VERSION[vardepsexclude] += "DATETIME"
+INHERIT += "ostro-version"
 
 # Ostro OS tries to build minimal images and thus prefers Busybox or
 # Toybox over coreutils or any other package providing similar


### PR DESCRIPTION
Since eSDK uses an overriden form for OS_VERSION calculation,
but with wrong input, we'd better have a single definition
for OS_VERSION where we can check the input.

Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>