### PR TITLE
CI: simplify auto.conf in eSDK

### DIFF
--- a/meta-ostro/classes/ostroproject-ci.bbclass
+++ b/meta-ostro/classes/ostroproject-ci.bbclass
@@ -1,0 +1,23 @@
+# Used by ostroproject-ci.inc to make some changes which cannot be done
+# directly in the include file.
+
+# The CI uses auto.conf to make some changes which are meant to be active
+# only in the CI, like enabling isafw and buildhistory. None of those
+# are meant to be active when normal developers use the eSDK. At best
+# they cause overhead, but others (like making OS_VERSION depend on
+# a CI variable) outright prevent using the eSDK.
+#
+# Instead of trying to filter the auto.conf, we take full control
+# over its content here.
+python ostroproject_ci_clean_auto () {
+    autoconf = d.expand('${SDK_OUTPUT}/${SDKPATH}/conf/auto.conf')
+    with open(autoconf, 'w') as f:
+        # MACHINE must be set.
+        f.write('MACHINE = "%s"\n' % d.getVar('MACHINE', True))
+        # Currently required because the user cannot add it themselves.
+        # It would be better if the users edited some file to choose
+        # the image mode.
+        f.write('require conf/distro/include/ostro-os-development.inc\n')
+}
+
+SDK_POSTPROCESS_COMMAND_append_task-populate-sdk-ext = "ostroproject_ci_clean_auto; "

--- a/meta-ostro/conf/distro/include/ostroproject-ci.inc
+++ b/meta-ostro/conf/distro/include/ostroproject-ci.inc
@@ -15,6 +15,9 @@ INHERIT += "buildstats-summary"
 # Enable CVE and other security checks.
 INHERIT += "isafw"
 
+# Additional CI specific tweaks.
+INHERIT += "ostroproject-ci"
+
 # Most of the images are expected to contain GPLv3
 # components. Therefore we only enable the license check for those
 # which must not have them (whitelisting), instead of excluding images


### PR DESCRIPTION
The auto.conf file is used by the CI system to make changes specific
only to the CI. Many of them are intentionally not enabled for
normal development by default, and setting OS_VERSION so that
it uses a CI variable breaks swupd-image creation in the eSDK
because the variable isn't set.

So instead of using the auto.conf created by the CI system, we
create one specifically for the eSDK. Currently two changes are
done this way:
- MACHINE
- configuring images as "development images"

That we have to do the later without explicit user consent
is unfortunate; the original goal of the mechanism was that
users must confirm that they want to build images which aren't
suitable for production. With the eSDK that is currently
not possible.

This is an alternative to PR #230