### PR TITLE
ostro: switch to latest swupd 3.6.0

### DIFF
--- a/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
+++ b/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
@@ -49,6 +49,7 @@ bison@core
 bluetooth-rfkill-event@edison
 bluez5@core
 boost@core
+bsdiff@meta-swupd
 busybox@core
 bzip2@core
 ca-certificates@core

--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -117,14 +117,6 @@ DISTRO_FEATURES_DEFAULT_remove = "x11 3g"
 
 DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_LIBC} ${OSTRO_DEFAULT_DISTRO_FEATURES}"
 
-# Currently Ostro OS is still using swupd 2.x because that is what
-# has been tested with most. The newer 3.x will be tested right after
-# the initial swupd integration.
-PREFERRED_VERSION_swupd-client ?= "2.%"
-PREFERRED_VERSION_swupd-client-native ?= "2.%"
-PREFERRED_VERSION_swupd-server ?= "2.%"
-PREFERRED_VERSION_swupd-server-native ?= "2.%"
-
 # Use 4.4 kernel for meta-intel BSP MACHINEs
 # BeagleBone is still on 4.1 until meta-yocto-bsp switches it over
 PREFERRED_VERSION_linux-yocto_intel-corei7-64 ?= "4.4%"


### PR DESCRIPTION
@igor-stoppa: we need to start building in the CI system now to get
this into the snapshot today. Therefore I went ahead and prepared this
PR.

I discussed the upcoming "enforce signature check unless explicitly
disable" patch with @ereshetova and she agreed that it is okay to use
3.6.0 without that patch for now, as long as we add that patch as soon
as it is available.