### PR TITLE
The UEFI app depends on the kernel command line

### DIFF
--- a/meta-ostro/classes/image-dsk.bbclass
+++ b/meta-ostro/classes/image-dsk.bbclass
@@ -299,6 +299,7 @@ export PART_%(pnum)d_FS=%(filesystem)s
 
 DEPLOYDIR = "${WORKDIR}/uefiapp-${PN}"
 SSTATETASKS += "do_uefiapp"
+do_uefiapp[vardeps] += " APPEND"
 do_uefiapp[sstate-inputdirs] = "${DEPLOYDIR}"
 do_uefiapp[sstate-outputdirs] = "${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}-uefiapp"
 


### PR DESCRIPTION
If the kernel command line changes, the UEFI app must be rebuilt,
to reflect the change.

Signed-off-by: Igor Stoppa <igor.stoppa@intel.com>