### PR TITLE
local.conf: disable packaging of source code

### DIFF
--- a/meta-ostro/conf/layer.conf
+++ b/meta-ostro/conf/layer.conf
@@ -35,7 +35,7 @@ BBFILE_PRIORITY_ostro = "6"
 #
 # A separate, Ostro OS specific variable is used to make the value
 # available to derived distros.
-OSTRO_OS_LOCALCONF_VERSION = "3"
+OSTRO_OS_LOCALCONF_VERSION = "4"
 LOCALCONF_VERSION = "${OSTRO_OS_LOCALCONF_VERSION}"
 
 # Same for LCONF_VERSION in bblayer.conf.sample.

--- a/meta-ostro/conf/local.conf.sample
+++ b/meta-ostro/conf/local.conf.sample
@@ -249,7 +249,7 @@ SSTATE_MIRRORS ?= "file://.* http://download.ostroproject.org/sstate/ostro-os/PA
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
 # track the version of this file when it was generated. This can safely be ignored if
 # this doesn't mean anything to you.
-CONF_VERSION = "3"
+CONF_VERSION = "4"
 
 #
 # ISAFW: https://github.com/01org/isafw
@@ -273,6 +273,15 @@ SUPPORTED_RECIPES_CHECK = "fatal"
 #
 # Alternatively, uncomment the following line to make it a non-fatal warning:
 #SUPPORTED_RECIPES_CHECK = "warn"
+
+# Ostro OS does not package source code in dbg packages because our
+# images include valgrind, and valgrind depends on the glibc dbg
+# package. Including source code in dbg packages would therefore make
+# the images larger than they normally need to be.
+#
+# If you need source code packaged and installed on images, comment out
+# the following line.
+PACKAGE_DEBUG_SPLIT_STYLE = "debug-without-src"
 
 # An explicit choice must be made between building Ostro OS
 # development images and production images. See


### PR DESCRIPTION
I tested this mode locally before creating the PR. The PR itself
still needs to be verified (i.e. we need to look at the content
of the resulting images).