### PR TITLE
ima_policy_ostro: enable tracefs access

### DIFF
--- a/meta-ostro/recipes-image/images/files/ima_policy_ostro
+++ b/meta-ostro/recipes-image/images/files/ima_policy_ostro
@@ -56,6 +56,9 @@ dont_measure fsmagic=0x27e0eb
 # EFIVARFS_MAGIC
 dont_appraise fsmagic=0xde5e81e4
 dont_measure fsmagic=0xde5e81e4
+# TRACEFS_MAGIC
+dont_appraise fsmagic=0x74726163
+dont_measure fsmagic=0xde5e81e4
 # MSDOS_SUPER_MAGIC
 # Excluded for external USB sticks. Does not
 # support xattrs anyway.


### PR DESCRIPTION
@rojkov please confirm. For reference:

.../linux-yocto-4.4$ git grep TRACEFS_MAGIC
fs/tracefs/inode.c:     err  =  simple_fill_super(sb, TRACEFS_MAGIC, trace_files);
include/uapi/linux/magic.h:#define TRACEFS_MAGIC          0x74726163

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>