### PR TITLE
default-ip6tables.rules: Update ipv6 firewall rules

### DIFF
--- a/meta-ostro/recipes-security/iptables-settings-default/files/default-ip6tables.rules
+++ b/meta-ostro/recipes-security/iptables-settings-default/files/default-ip6tables.rules
@@ -7,6 +7,7 @@
 # allow containers to access DHCP service
 -A INPUT -i ve-+ -p udp -m udp --dport 67 -j ACCEPT
 -A INPUT -s fe80::/10 -j ACCEPT
+-A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -p ipv6-icmp -j ACCEPT
 # allow forwarding traffic to/from containers

--- a/meta-ostro/recipes-security/iptables-settings-default/files/default-ip6tables.rules
+++ b/meta-ostro/recipes-security/iptables-settings-default/files/default-ip6tables.rules
@@ -4,10 +4,9 @@
 :OUTPUT ACCEPT
 # allow containers to access DNS service
 -A INPUT -i ve-+ -p udp -m udp --dport 53 -j ACCEPT
-# allow containers to access DHCP service
--A INPUT -i ve-+ -p udp -m udp --dport 67 -j ACCEPT
--A INPUT -s fe80::/10 -j ACCEPT
 -A INPUT -i lo -j ACCEPT
+# allow DHCPv6
+-A INPUT -s fe80::/10 -p udp -m udp --dport 546 -j ACCEPT
 -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -p ipv6-icmp -j ACCEPT
 # allow forwarding traffic to/from containers


### PR DESCRIPTION
Pythons unit test (test_nntplib.py) fails because firewall doesn't
allow ipv6 input to localhost. Adding a rule from iptables.rules to
ip6tables.rules fixes this.

Signed-off-by: Simo Kuusela <simo.kuusela@intel.com>