### PR TITLE
iotsstatetests.py: python3: convert stdout byte stream to str

### DIFF
--- a/meta-ostro/lib/oeqa/selftest/iotsstatetests.py
+++ b/meta-ostro/lib/oeqa/selftest/iotsstatetests.py
@@ -127,7 +127,7 @@ MACHINE = \"%s\"
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
                 stdout, stderr = p.communicate()
-                analysis.append(stdout)
+                analysis.append(stdout.decode("utf-8"))
         if len(errors) > 1:
             # If this fails, it often fails for a whole range of tasks where one depends on
             # the other. In this example, only the original source file was different:


### PR DESCRIPTION
The subprocess.PIPE as stdout returns byte stream and thus cannot be
used with str.join().

Convert the byte stream to str to avoid a TypeError with str.join():
"TypeError: sequence item 0: expected str instance, bytes found"

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>