### PR TITLE
fixes: iotivity apps: skip "ldflags" QA tes

### DIFF
--- a/meta-ostro/fixes/meta-oic/recipes-apps/iotivity-sensorboard/iotivity-sensorboard_%.bbappend
+++ b/meta-ostro/fixes/meta-oic/recipes-apps/iotivity-sensorboard/iotivity-sensorboard_%.bbappend
@@ -1,0 +1,8 @@
+# openembedded-core now correctly reveals if the build system
+# LDFLAGS aren't used (see openembedded-core commit
+# a98a8180863ff45b477a1f8439ebcec21151d282).
+#
+# iotivity-sensorboard is one of the components that does not obey LDFLAGS.
+#
+# Temporarily skip "ldflags" to overcome the issue.
+INSANE_SKIP_${PN} += "ldflags"

--- a/meta-ostro/fixes/meta-oic/recipes-apps/iotivity-simple-client/iotivity-simple-client_%.bbappend
+++ b/meta-ostro/fixes/meta-oic/recipes-apps/iotivity-simple-client/iotivity-simple-client_%.bbappend
@@ -1,0 +1,8 @@
+# openembedded-core now correctly reveals if the build system
+# LDFLAGS aren't used (see openembedded-core commit
+# a98a8180863ff45b477a1f8439ebcec21151d282).
+#
+# iotivity-simple-client is one of the components that does not obey LDFLAGS.
+#
+# Temporarily skip "ldflags" to overcome the issue.
+INSANE_SKIP_${PN} += "ldflags"

--- a/meta-ostro/fixes/meta-oic/recipes-core/iotivity/iotivity_%.bbappend
+++ b/meta-ostro/fixes/meta-oic/recipes-core/iotivity/iotivity_%.bbappend
@@ -3,7 +3,7 @@
 # a98a8180863ff45b477a1f8439ebcec21151d282).
 #
 # iotivity is one of the components that does not obey LDFLAGS.
-# However, fixing it§ needs a lot of rework in iotivity's scons
+# However, fixing it needs a lot of rework in iotivity's scons
 # scripts. 
 #
 # Temporarily skip "ldflags" for all PACKAGES:


### PR DESCRIPTION
openembedded-core now correctly reveals if the build system
LDFLAGS aren't used (see openembedded-core commit
a98a8180863ff45b477a1f8439ebcec21151d282).

iotivity sample apps do not obey LDFLAGS. However, fixing it needs
meta-oic changes and that takes long time.

Temporarily skip "ldflags" for iotivity sample apps.