### PR TITLE
supported-recipes: add libunistring

### DIFF
--- a/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
+++ b/meta-ostro/conf/distro/include/ostro-supported-recipes.txt
@@ -150,6 +150,7 @@ libpcre@core
 libpng@core
 libsocketcan@openembedded-layer
 libtool@core
+libunistring@core
 liburcu@core
 libusb-compat@core
 libusb1@core


### PR DESCRIPTION
The new version of gnutls pulled in from OE-Core adds a
dependency to libunistring.

Add libunistring to the list of supported recipes to get builds
going.

Signed-off-by: Mikko Ylinen <mikko.ylinen@linux.intel.com>